### PR TITLE
Allow APIURL to be set from ENV Variables

### DIFF
--- a/src/environment/env.dev.js
+++ b/src/environment/env.dev.js
@@ -3,7 +3,7 @@
 export const environment = {
     production: false,
     environment: 'dev',
-    apiUrl: 'http://localhost:3100'
+    apiUrl:  process.env.REACT_APP_APIURL || 'http://localhost:3100'
 
   };
   


### PR DESCRIPTION
Example Usage:
```
REACT_APP_APIURL="http://my.own.loki:3100" PORT=3101 npm start
```