### PR TITLE
Fixed ordering of data views

### DIFF
--- a/src/components/DataViews/index.js
+++ b/src/components/DataViews/index.js
@@ -1,6 +1,7 @@
 import { ThemeProvider } from "@emotion/react";
 import { useMemo, useState } from "react";
 import { useSelector } from "react-redux";
+import store from "../../store/store";
 import { themes } from "../../theme/themes";
 import { DataViewItem } from "./components/DataViewItem";
 import { DataviewsContainer } from "./styled";
@@ -10,9 +11,12 @@ export default function DataViews(props) {
     const theme = useSelector((store) => store.theme);
     const [side] = useState(name);
     const dataViews = useSelector((store) => store[`${side}DataView`]);
+    const queries = useSelector((store) => store[side]);
     const viewsMemo = useMemo(()=>{
-    return dataViews
-    },[dataViews])
+        return dataViews.sort((a,b) => {
+            return queries.findIndex((query) => query.id === a.id) - queries.findIndex((query) => query.id === b.id)
+        })
+    },[dataViews, queries])
     if (viewsMemo.length > 0 ) {
 
         return (


### PR DESCRIPTION
- Dataviews are ordered in the same way queries are ordered instead of "most recent at the bottom" for demo of previous behavior look at:  #188 
Fixed demo: 
![chrome_2022-12-20_12-31-57](https://user-images.githubusercontent.com/45398541/208646111-4536a793-3f77-457a-9627-f5aae3435cc9.gif)
