### PR TITLE
fix: show results button action inside history #185

### DIFF
--- a/src/components/LabelBrowser/components/QueryBar.js
+++ b/src/components/LabelBrowser/components/QueryBar.js
@@ -263,9 +263,6 @@ export const QueryBar = (props) => {
         }
     }, [isTabletOrMobile]);
 
-  
-
-
     // changes on changin dataSource Id
 
     useEffect(() => {
@@ -375,7 +372,6 @@ export const QueryBar = (props) => {
         }
     }, [dataSourceId, id]);
 
-
     // changes on changing exp
 
     useEffect(() => {
@@ -407,9 +403,19 @@ export const QueryBar = (props) => {
 
     const onSubmit = (e) => {
         e.preventDefault();
-        if (onQueryValid(queryInput)) {
+        const ds = dataSources.find((f) => f.id === dataSourceId);
+        if (onQueryValid(queryInput) && ds) {
             try {
-                updateHistory(queryInput, queryType, limit, id);
+                updateHistory(
+                    ds.type,
+                    queryInput,
+                    queryType,
+                    limit,
+                    id,
+                    direction,
+                    ds.id,
+                    ds.url
+                );
 
                 // Decode query to translate into labels selection
                 decodeQueryAndUpdatePanel(queryInput, true);
@@ -489,14 +495,14 @@ export const QueryBar = (props) => {
         setLocalStorage();
     };
 
-    const onSubmitRate = (e, type = "logs") => {
+    const onSubmitRate = (e) => {
         e.preventDefault();
         const isEmptyQuery = queryInput.length === 0;
         let query = "";
         if (!isEmptyQuery) {
             const isRate = queryInput.startsWith(`rate(`);
 
-            if (type === "metrics") {
+            if (dataSourceType === "metrics") {
                 if (isRate) {
                     query = queryInput.replace(/{([^}]+)}/g, "{}");
                     query = query.replace(/\[\d+ms\]/, "[$__interval]");
@@ -520,9 +526,21 @@ export const QueryBar = (props) => {
 
             setQueryValid(onQueryValid(query));
         }
+
         if (onQueryValid(query)) {
+            const ds = dataSources.find((f) => f.id === dataSourceId);
+
             try {
-                updateHistory(query, queryType, limit, id);
+                updateHistory(
+                    ds.type,
+                    query,
+                    queryType,
+                    limit,
+                    id,
+                    direction,
+                    ds.id,
+                    ds.url
+                );
                 // Decode query to translate into labels selection
                 decodeQueryAndUpdatePanel(query, true);
 
@@ -536,13 +554,25 @@ export const QueryBar = (props) => {
         }
     };
 
-    const updateHistory = (queryInput, queryType, limit, id) => {
+    const updateHistory = (
+        type,
+        queryInput,
+        queryType,
+        limit,
+        id,
+        direction,
+        dataSourceId,
+        url
+    ) => {
         const historyUpdated = historyService.add({
             data: JSON.stringify({
-                type: dataSourceType,
+                type,
                 queryInput,
                 queryType,
                 limit,
+                direction,
+                dataSourceId: dataSourceId,
+                url,
                 panel: name,
                 id,
             }),
@@ -623,7 +653,7 @@ export const QueryBar = (props) => {
         }
     };
     const updateLinksHistory = () => {
-        const ds = dataSources.find( f => f.id === dataSourceId)
+        const ds = dataSources.find((f) => f.id === dataSourceId);
         const storedUrl = saveUrl.add({
             data: {
                 href: window.location.href,
@@ -707,8 +737,6 @@ export const QueryBar = (props) => {
         return null;
     }
 
-
-
     const queryTypeRenderer = (
         type,
         traceSearch,
@@ -771,9 +799,9 @@ export const QueryBar = (props) => {
                             handleHistoryClick={handleHistoryClick}
                             queryValid={queryValid}
                             onSubmit={onSubmit}
-                            onSubmitRate={onSubmitRate}
+                            onSubmitRate={onSubmitRate} 
                             labels={labels}
-                            loading={loading||false}
+                            loading={loading || false}
                             hasStats={hasStats}
                             showStatsOpen={showStatsOpen}
                             handleStatsOpen={handleStatsOpen}
@@ -801,7 +829,7 @@ export const QueryBar = (props) => {
                         onSubmitRate={onSubmitRate}
                         isTabletOrMobile={isTabletOrMobile}
                         labels={labels}
-                        loading={loading||false}
+                        loading={loading || false}
                     />,
                     <MetricsSearch
                         {...props}
@@ -817,7 +845,7 @@ export const QueryBar = (props) => {
                         logsRateButton={
                             <ShowLogsRateButton
                                 disabled={!queryValid}
-                                onClick={(e) => onSubmitRate(e, "metrics")}
+                                onClick={onSubmitRate}
                                 isMobile={false}
                                 alterText={"Use as Rate Query"}
                             />
@@ -838,7 +866,7 @@ export const QueryBar = (props) => {
                     <ShowLogsButton
                         disabled={!queryValid}
                         onClick={onSubmit}
-                        loading={loading||false}
+                        loading={loading || false}
                         isMobile={false}
                         alterText={"Search Trace"}
                     />
@@ -921,7 +949,7 @@ export const QueryBarCont = (props) => {
                         disabled={!queryValid}
                         onClick={onSubmit}
                         isMobile={false}
-                        loading={loading||false}
+                        loading={loading || false}
                     />
                 </>
             )}
@@ -933,14 +961,13 @@ export const QueryBarCont = (props) => {
                             disabled={!queryValid}
                             onClick={onSubmit}
                             isMobile={false}
-                            loading={loading||false}
+                            loading={loading || false}
                         />
                     </>
                 )}
         </QueryBarContainer>
     );
 };
-
 
 // mobile top query view (mobile view or splitted view)
 export const MobileTopQueryMenuCont = (props) => {
@@ -1034,7 +1061,7 @@ export const MobileTopQueryMenuCont = (props) => {
                 disabled={!queryValid}
                 onClick={onSubmit}
                 isMobile={true}
-                loading={loading||false}
+                loading={loading || false}
             />
 
             {dataSourceType === "flux" && (

--- a/src/plugins/queryhistory/index.js
+++ b/src/plugins/queryhistory/index.js
@@ -639,7 +639,7 @@ const QueryHistory = (props) => {
     const [linksStarredFiltered, setLinksStarredFiltered] = useState([]);
     const [starredFiltered, setStarredFiltered] = useState([]);
     const [linksStarredItems, setLinksStarredItems] = useState(false);
-
+    const { start, stop } = useSelector((store) => store);
     function handleDelete(id) {
         const removed = historyService.remove(id);
         dispatch(setQueryHistory(removed));
@@ -678,18 +678,50 @@ const QueryHistory = (props) => {
             panel,
             queryInput,
             queryType,
-            dataSourceType,
+            type,
+            dataSourceId,
+            url,
+
             direction,
         } = logData;
+
+        let querySubmit = "";
+
+        let customStep = 0;
+
+        if (queryInput.includes(`$__interval`)) {
+            const timeDiff = (stop.getTime() - start.getTime()) / 1000;
+
+            const timeProportion = timeDiff / 30;
+
+            const screenProportion = (1).toFixed(1);
+
+            const intval = timeProportion / screenProportion;
+
+            const ratiointval = Math.round(
+                intval * window.devicePixelRatio.toFixed(2)
+            );
+            querySubmit = queryInput.replace(
+                "[$__interval]",
+                `[${ratiointval}s]`
+            );
+            customStep = ratiointval;
+        } else {
+            querySubmit = queryInput;
+        }
+
         dispatch(
             getData(
-                dataSourceType,
-                queryInput,
+                type,
+                querySubmit,
                 queryType,
                 limit,
                 panel,
                 id,
-                direction
+                direction || "forward",
+                dataSourceId,
+                url,
+                customStep
             )
         );
     }
@@ -908,10 +940,10 @@ const QueryHistory = (props) => {
                                 filteredQueries={starredFiltered}
                                 filteredLinks={linksStarredFiltered}
                                 emptyQueryMessage={
-                                    "Click the ‘Star’ icon to save links and find them here to reuse again"
+                                    "Click the 'Star' icon to save links and find them here to reuse again"
                                 }
                                 emptyLinkMessage={
-                                    "Click the ‘Star’ icon to save queries and find them here to reuse again"
+                                    "Click the 'Star' icon to save queries and find them here to reuse again"
                                 }
                                 copyQuery={copyQuery}
                             />


### PR DESCRIPTION
Fixed:
Submit button inside History For:
 - Logs (show results & show logs rate)
 - Metrics (use query & use rate query)
 - Traces (search trace)
 Data will be shown inside same query 