### PR TITLE
Fix loading

### DIFF
--- a/src/actions/getData.ts
+++ b/src/actions/getData.ts
@@ -13,6 +13,9 @@ import { getTimeSpan } from "./helpers/getTimeSpan";
 import { boscoSend } from "./helpers/boscoRequest";
 import { setLeftPanel } from "./setLeftPanel";
 import { setRightPanel } from "./setRightPanel";
+import { DataViews } from "../store/store.model";
+import { setLeftDataView } from "./setLeftDataView";
+import { setRightDataView } from "./setRightDataView";
 
 /**
  *
@@ -36,7 +39,12 @@ function panelDispatch(panel: string, dispatch: Function, data: any) {
         return dispatch(setRightPanel(data));
     }
 }
-
+export function dataViewDispatch(panel: string, dataViews: DataViews, dispatch: Function) {
+    if (panel === "left") {
+        return dispatch(setLeftDataView(dataViews));
+    }
+    return dispatch(setRightDataView(dataViews));
+}
 function changeLoadingState(panel: any[], id: string, state: boolean) {
     return [...panel].map((m) => {
         if (m.id === id) {
@@ -150,10 +158,17 @@ export default function getData(
     );
 
     const endpoint = getEndpoint(type, queryType, params);
-
+    const setLoading = (state: boolean, dispatch: Function) => {
+        const dataViews: DataViews = store.getState()?.[`${panel}DataView`];
+        const dataView = dataViews?.find((view) => view.id === id);
+        if (dataView) {
+            dataView.loading = state;
+        }
+        dataViewDispatch(panel, dataViews, dispatch);
+    }
     return async function (dispatch: Function) {
         await resetParams(dispatch, panel);
-        dispatch(setLoading(true));
+        setLoading(true, dispatch);
         loadingState(dispatch, true);
         let cancelToken: any;
 
@@ -187,13 +202,13 @@ export default function getData(
                     .catch((error) => {
                         resetNoData(dispatch);
                         dispatch(setIsEmptyView(true));
-                        dispatch(setLoading(false));
+                        setLoading(false, dispatch)
                         if (debugMode) {
                             console.log("Error loading flux data", error);
                         }
                     })
                     .finally(() => {
-                        dispatch(setLoading(false));
+                        setLoading(false, dispatch)
                         loadingState(dispatch, false);
                     });
             } else if (options?.method === "GET") {
@@ -224,7 +239,7 @@ export default function getData(
                     .catch((error) => {
                         resetNoData(dispatch);
                         dispatch(setIsEmptyView(true));
-                        dispatch(setLoading(false));
+                        setLoading(false, dispatch)
                         loadingState(dispatch, false);
                         if (debugMode) {
                             boscoSend(
@@ -240,7 +255,7 @@ export default function getData(
                     })
                     .finally(() => {
                         loadingState(dispatch, false);
-                        dispatch(setLoading(false));
+                        setLoading(false, dispatch)
                     });
             }
         } catch (e) {

--- a/src/actions/helpers/resetParams.ts
+++ b/src/actions/helpers/resetParams.ts
@@ -8,7 +8,6 @@ import { setVectorData } from "../setVectorData";
 
 
 export async function resetParams(dispatch: Function,panel:string) {
-    dispatch(setLoading(true));
     dispatch(setIsEmptyView(false));
     dispatch(setLogs([]));
 

--- a/src/components/DataViews/components/DataViewItem.js
+++ b/src/components/DataViews/components/DataViewItem.js
@@ -9,8 +9,7 @@ import { TraceView } from "./Traces/TraceView.tsx";
 export function DataViewItem(props) {
     // add a header for table view / json view
     const { dataView, name, vHeight } = props;
-    const { type, total } = dataView;
-
+    const { type, total, loading } = dataView;
     const viewRef = useRef(null);
     const isSplit = useSelector((store) => store.isSplit);
     const panel = useSelector((store) => store[name]);
@@ -153,6 +152,7 @@ export function DataViewItem(props) {
             setMaxHeight,
             actualQuery,
             total,
+            loading,
             ...props,
         };
 

--- a/src/components/DataViews/components/EmptyViewCont.js
+++ b/src/components/DataViews/components/EmptyViewCont.js
@@ -3,9 +3,9 @@ import { useSelector } from "react-redux";
 import { themes } from "../../../theme/themes";
 import { EmptyViewContainer } from "../styled";
 
-export default function EmptyViewCont() {
+export default function EmptyViewCont(props) {
     const theme = useSelector((store) => store.theme);
-    const loading = useSelector((store) => store.loading);
+    const { loading } = props;
     return (
         !loading && (
             <ThemeProvider theme={themes[theme]}>

--- a/src/components/DataViews/views/EmptyView.js
+++ b/src/components/DataViews/views/EmptyView.js
@@ -11,6 +11,7 @@ export function EmptyView(props) {
         setMaxHeight,
         actualQuery,
         total,
+        loading
     } = props;
 
     return (
@@ -25,7 +26,7 @@ export function EmptyView(props) {
                 fixedSize={true}
                 {...props}
             />
-            <EmptyViewCont />
+            <EmptyViewCont loading={loading} />
         </ViewStyled>
     );
 }

--- a/src/components/LabelBrowser/components/styled/index.ts
+++ b/src/components/LabelBrowser/components/styled/index.ts
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import isPropValid from '@emotion/is-prop-valid'
 
 import HistoryIcon from "@mui/icons-material/History";
 import { BtnSmall as btnSmall } from "../../../../theme/styles/Button";
@@ -52,7 +53,9 @@ export const QueryBarContainer = styled.div`
     flex-wrap: wrap;
     border-radius: 3px;
 `;
-export const ShowLogsBtn = styled(BtnSmall)`
+export const ShowLogsBtn = styled(BtnSmall, {
+    shouldForwardProp: prop => isPropValid(prop) && prop !== 'loading'
+})`
     background: ${(props) => props.loading ? '#44bcd8' : props.theme.primaryDark};
     border: 1px solid ${(props) => props.theme.buttonBorder};
     color: ${(props) => props.theme.buttonText};

--- a/src/store/store.model.ts
+++ b/src/store/store.model.ts
@@ -35,8 +35,8 @@ export interface Store {
     isEmbed:            string;
     left:               Panel[];
     right:              Panel[];
-    leftDataView:       any[];
-    rightDataView:      any[];
+    leftDataView:       DataViews;
+    rightDataView:      DataViews;
     chartType:          string;
     resposeType:        string;
     notifications:      any[];
@@ -107,4 +107,50 @@ export interface URLQueryParams {
     theme:     string;
     isSplit:   string;
     autoTheme: string;
+}
+export type DataViews = DataView[]; 
+
+export interface DataView {
+    id:        string;
+    type:      string;
+    tableData: TableData;
+    data:      Datum[];
+    labels:    string[];
+    total:     number;
+    loading:   boolean;
+}
+
+export interface Datum {
+    type:       string;
+    timestamp:  number;
+    text:       string;
+    tags:       Tags;
+    isShowTs:   boolean;
+    showLabels: boolean;
+    id:         string;
+}
+
+export interface Tags {
+    job:   string;
+    level: string;
+}
+
+export interface TableData {
+    columnsData: ColumnsDatum[];
+    dataRows:    DataRow[];
+    length:      number;
+}
+
+export interface ColumnsDatum {
+    Header:    string;
+    accessor:  string;
+    width?:    number;
+    minWidth?: number;
+    maxWidth?: number;
+}
+
+export interface DataRow {
+    time:   string;
+    stream: string;
+    log:    string;
 }


### PR DESCRIPTION
#193: `loading` flag was for whole app, which caused unnecessary re-renders and blinking on empty dataviews. 
Now flag is per dataview.