### PR TITLE
fix: Label Browser will open upon Keypressup #219

### DIFF
--- a/src/components/LabelBrowser/components/QueryBar.js
+++ b/src/components/LabelBrowser/components/QueryBar.js
@@ -573,7 +573,7 @@ export const QueryBar = (props) => {
                     query.expr = queryExpr;
                 }
                 query.labels = [...labelsDecoded];
-                query.browserOpen = !isSearch && dataSourceType === "logs";
+                query.browserOpen = false;
                 query.dataSourceId = currentDataSource.id;
                 query.dataSourceType = currentDataSource.type;
                 query.dataSourceURL = currentDataSource.url;


### PR DESCRIPTION
Resolution: 
- Labels browser will open now only when the labels browser open button is clicked.