### PR TITLE
feat: origin as datasource by default at datasources page

### DIFF
--- a/packages/main/views/DataSources/store/setDataSources.ts
+++ b/packages/main/views/DataSources/store/setDataSources.ts
@@ -1,4 +1,4 @@
-const setDataSources = (dataSources: any) => (dispatch: Function) => {
+const setDataSources = (dataSources: any) => (dispatch: any) => {
     dispatch({
         type: 'SET_DATA_SOURCES',
         dataSources


### PR DESCRIPTION
- Fixes the default url at datasources when there is not setting at all as the window.location.origin url (URL : PORT) 
- Set the default url for 'one url for all' input as same as the logs datasource (default one) when there is a logs datasource with a valid url
- Opens the 'one for all' widget by default when there is not setting and automatically sets all dataources by default to the window.location.origin.