### PR TITLE
fix: datasources cancel button

### DIFF
--- a/packages/main/views/DataSources/ConfirmDialog.tsx
+++ b/packages/main/views/DataSources/ConfirmDialog.tsx
@@ -1,0 +1,84 @@
+import * as React from "react";
+import { Button } from "./ui";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import DOMPurify from "isomorphic-dompurify";
+import useTheme from "@ui/theme/useTheme";
+
+export type ConfirmDialogProps = {
+    saveDataSource: () => void;
+    changed: boolean;
+};
+
+export default function ConfirmDialog({
+    saveDataSource,
+    changed,
+}: ConfirmDialogProps) {
+    const [open, setOpen] = React.useState(false);
+    const theme = useTheme();
+    const handleClickOpen = () => {
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    const handleSave = () => {
+        saveDataSource();
+        handleClose();
+    };
+
+    const handleCancel = () => {
+        handleClose();
+    };
+
+    return (
+        <React.Fragment>
+            <Button
+                primary={changed}
+                value={DOMPurify.sanitize("Save")}
+                onClick={handleClickOpen}
+            />
+
+            <Dialog
+                open={open}
+                onClose={handleClose}
+                aria-labelledby="alert-dialog-title"
+                aria-describedby="alert-dialog-description"
+            >
+                <DialogTitle
+                    id="alert-dialog-title"
+                    style={{ background: theme.shadow, color: theme.contrast }}
+                >
+                    {"Save DataSource Settings"}
+                </DialogTitle>
+                <DialogContent style={{ background: theme.shadow }}>
+                    <DialogContentText
+                        style={{ color: theme.contrast }}
+                        id="alert-dialog-description"
+                    >
+                        Are you sure you want to store and modify current
+                        DataSource settings?
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions style={{ background: theme.shadow }}>
+                    <Button
+                        onClick={handleCancel}
+                        value={DOMPurify.sanitize("Cancel")}
+                        primary={false}
+                    />
+                    <Button
+                        value={DOMPurify.sanitize("Save")}
+                        onClick={handleSave}
+                        primary={changed}
+                        autoFocus
+                    />
+                </DialogActions>
+            </Dialog>
+        </React.Fragment>
+    );
+}

--- a/packages/main/views/DataSources/DataSource.tsx
+++ b/packages/main/views/DataSources/DataSource.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from "@emotion/css";
 import { ThemeProvider } from "@emotion/react";
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useCookies } from "react-cookie";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
@@ -56,6 +56,8 @@ export function DataSourceSetting(props: any) {
         "qryn-dev-cookie",
         "qryn-settings",
     ]); // for testing cookies feature
+
+  
     const dispatch: any = useDispatch();
     const dataSources = useSelector((store: any) => store.dataSources);
     const useForAll = () => {
@@ -169,7 +171,7 @@ export function DataSourceSetting(props: any) {
             </div>
 
             <div className="ds-settings">
-                <Settings {...props} />
+                <Settings {...props}  />
             </div>
         </div>
     );
@@ -193,7 +195,11 @@ export const DataSourceSettingHeader = (props: any) => {
 export function DataSource() {
     let { id } = useParams();
     const theme = useTheme();
+    const dispatch:any = useDispatch()
+
     const dataSources = useSelector((store: any) => store.dataSources);
+    const [dataChanged, setDataChanged] = useState([])
+
     const datasource = useMemo(() => {
         if (!dataSources || dataSources.length === 0) {
             return {};
@@ -202,6 +208,13 @@ export function DataSource() {
         return dataSources.find((f: any) => f.id === id) || {};
     }, [id, dataSources]);
 
+    const saveSettings = () => useCallback(()=>{
+        dispatch(setDataSources(dataChanged))
+        localStorage.setItem("dataSources", JSON.stringify(dataChanged));
+    },[dataChanged])
+
+
+
     return (
         <ThemeProvider theme={theme}>
             <Container>
@@ -209,9 +222,12 @@ export function DataSource() {
                     <Header
                         title={"DataSource Settings"}
                         datasource={datasource}
+                        onSave={saveSettings}
                     />
                     <div className={"datasource-body"}>
-                        <DataSourceSetting {...datasource} />
+                        <DataSourceSetting
+                         {...datasource} 
+                         saveSettings={setDataChanged}  />
                     </div>
                 </div>
             </Container>

--- a/packages/main/views/DataSources/DataSource.tsx
+++ b/packages/main/views/DataSources/DataSource.tsx
@@ -5,7 +5,8 @@ import { useCookies } from "react-cookie";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 import { createAlert } from "@ui/store/actions";
-
+import ConfirmDialog from "./ConfirmDialog";
+import { useStoreSettings } from "./hooks/useStoreSettings";
 import { Header } from "./components";
 import setDataSources from "./store/setDataSources";
 import { Container } from "./styles/Container";
@@ -59,6 +60,23 @@ export function DataSourceSetting(props: any) {
 
     const dispatch: any = useDispatch();
     const dataSources = useSelector((store: any) => store.dataSources);
+    const isDsSaved = useSelector((store: any) => store.isDsSaved);
+    const { storeDataSources, setSettings } = useStoreSettings();
+
+    const onSave = () => {
+        storeDataSources();
+        dispatch(
+            createAlert({
+                type: "success",
+                message: "Data Source Setting Saved SuccessFully",
+            })
+        );
+    };
+
+    const cancelAction = () => {
+        setSettings(dataSources);
+    };
+
     const useForAll = () => {
         const dsCP = [...dataSources];
         const prevDs = JSON.parse(JSON.stringify(dsCP));
@@ -140,22 +158,30 @@ export function DataSourceSetting(props: any) {
         link.click();
     }
 
+    // here should add buttons
+
     return (
         <div className="ds-cont">
             <div className={cx(HeaderRow)}>
                 <DataSourceSettingHeader {...props} />
-                <div style={{ display: "flex", alignItems: "center" }}>
+                <div
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: ".5em",
+                    }}
+                >
                     <Button
                         title={"Download Datasource settings as JSON"}
                         value={DOMPurify.sanitize("Download JSON")}
                         onClick={downLoadJson}
-                        primary={true}
+                        primary={false}
                     />
                     <Button
                         title={"Set Cookie with name: qryn-settings"}
                         value={DOMPurify.sanitize("Save Cookie")}
                         onClick={addCookie}
-                        primary={true}
+                        primary={false}
                     />
 
                     <Button
@@ -164,7 +190,25 @@ export function DataSourceSetting(props: any) {
                         }
                         value={DOMPurify.sanitize("Use For All")}
                         onClick={useForAll}
-                        primary={true}
+                        primary={false}
+                    />
+                </div>
+                <div
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "1em",
+                    }}
+                >
+                    <ConfirmDialog
+                        saveDataSource={onSave}
+                        changed={isDsSaved}
+                    />
+                    <Button
+                        value={DOMPurify.sanitize("Cancel")}
+                        onClick={cancelAction}
+                        editing={true}
+                        primary={false}
                     />
                 </div>
             </div>

--- a/packages/main/views/DataSources/DataSource.tsx
+++ b/packages/main/views/DataSources/DataSource.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from "@emotion/css";
 import { ThemeProvider } from "@emotion/react";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useCookies } from "react-cookie";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
@@ -57,7 +57,6 @@ export function DataSourceSetting(props: any) {
         "qryn-settings",
     ]); // for testing cookies feature
 
-  
     const dispatch: any = useDispatch();
     const dataSources = useSelector((store: any) => store.dataSources);
     const useForAll = () => {
@@ -171,7 +170,7 @@ export function DataSourceSetting(props: any) {
             </div>
 
             <div className="ds-settings">
-                <Settings {...props}  />
+                <Settings {...props} />
             </div>
         </div>
     );
@@ -195,10 +194,8 @@ export const DataSourceSettingHeader = (props: any) => {
 export function DataSource() {
     let { id } = useParams();
     const theme = useTheme();
-    const dispatch:any = useDispatch()
 
     const dataSources = useSelector((store: any) => store.dataSources);
-    const [dataChanged, setDataChanged] = useState([])
 
     const datasource = useMemo(() => {
         if (!dataSources || dataSources.length === 0) {
@@ -208,13 +205,6 @@ export function DataSource() {
         return dataSources.find((f: any) => f.id === id) || {};
     }, [id, dataSources]);
 
-    const saveSettings = () => useCallback(()=>{
-        dispatch(setDataSources(dataChanged))
-        localStorage.setItem("dataSources", JSON.stringify(dataChanged));
-    },[dataChanged])
-
-
-
     return (
         <ThemeProvider theme={theme}>
             <Container>
@@ -222,12 +212,9 @@ export function DataSource() {
                     <Header
                         title={"DataSource Settings"}
                         datasource={datasource}
-                        onSave={saveSettings}
                     />
                     <div className={"datasource-body"}>
-                        <DataSourceSetting
-                         {...datasource} 
-                         saveSettings={setDataChanged}  />
+                        <DataSourceSetting {...datasource} />
                     </div>
                 </div>
             </Container>

--- a/packages/main/views/DataSources/DataSources.tsx
+++ b/packages/main/views/DataSources/DataSources.tsx
@@ -42,8 +42,7 @@ export default function DataSources() {
         <ThemeProvider theme={theme}>
             <PageContainer>
                 <div className="cont">
-                    <List />
-
+          <List />
                     <div style={{ display: "flex", flex: 1 }}>
                         <div
                             style={{

--- a/packages/main/views/DataSources/components/AuthFields.tsx
+++ b/packages/main/views/DataSources/components/AuthFields.tsx
@@ -8,6 +8,7 @@ import { SectionHeader } from "./SectionHeader";
 import DOMPurify from "isomorphic-dompurify";
 
 export function AuthFields(props: any) {
+   // console.log(props)
     const { auth, id } = props;
     const dispatch: any = useDispatch();
 

--- a/packages/main/views/DataSources/components/AuthFields.tsx
+++ b/packages/main/views/DataSources/components/AuthFields.tsx
@@ -1,18 +1,24 @@
 import { useEffect, useMemo, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import setDataSources from "../store/setDataSources";
 import { InputCol, InputCont } from "../styles";
 import { QrynSwitch, Select, Field } from "../ui";
 import { TextAreaField } from "../ui/TextArea";
 import { SectionHeader } from "./SectionHeader";
 import DOMPurify from "isomorphic-dompurify";
 
-export function AuthFields(props: any) {
-   // console.log(props)
-    const { auth, id } = props;
-    const dispatch: any = useDispatch();
+export type AuthFieldsProps = {
+    auth?: any 
+    id?: string 
+    dataSources?: any 
+    onDsChange?: (prev:any) => void
+    fieldErrors?: any
+}
 
-    const dataSources = useSelector((store: any) => store.dataSources);
+export function AuthFields(props: AuthFieldsProps) {
+   // console.log(props)
+    const { auth, id, dataSources, onDsChange } = props;
+    //const dispatch: any = useDispatch();
+
+    //const dataSources = useSelector((store: any) => store.dataSources);
 
     const [activeFields, setActiveFields] = useState<any>([]);
     const [isEditing, setIsEditing] = useState(false);
@@ -46,9 +52,10 @@ export function AuthFields(props: any) {
             return dataSource;
         });
 
-        localStorage.setItem("dataSources", JSON.stringify(newDataSources));
+        onDsChange(()=> newDataSources)
+        //localStorage.setItem("dataSources", JSON.stringify(newDataSources));
 
-        dispatch(setDataSources(newDataSources));
+        //dispatch(setDataSources(newDataSources));
 
         return newDataSources;
     };
@@ -108,9 +115,9 @@ export function AuthFields(props: any) {
             return ds;
         });
 
-        localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-        dispatch(setDataSources(newDataSources));
-
+        //localStorage.setItem("dataSources", JSON.stringify(newDataSources));
+        //dispatch(setDataSources(newDataSources));
+        onDsChange(()=> newDataSources)
         setTimeout(() => {
             setIsEditing(() => false);
         }, 600);

--- a/packages/main/views/DataSources/components/AuthFields.tsx
+++ b/packages/main/views/DataSources/components/AuthFields.tsx
@@ -14,43 +14,34 @@ export type AuthFieldsProps = {
 };
 
 export function AuthFields(props: AuthFieldsProps) {
-    // console.log(props)
-   
     const { auth, id, dataSources, onDsChange } = props;
-    // const dispatch: any = useDispatch();
-    // console.log(auth)
-    // const dataSources = useSelector((store: any) => store.dataSources);
-
     const [activeFields, setActiveFields] = useState<any>([]);
     const [isEditing, setIsEditing] = useState(false);
     const fields = useMemo(() => {
-        if(auth) {    return Object.entries(auth)
-            ?.map(([name, field]: [name: any, field: any]) => ({
-                name,
-                ...field,
-            }))
-            .filter((f) => f.name !== "fields");
+        if (auth) {
+            return Object.entries(auth)
+                ?.map(([name, field]: [name: any, field: any]) => ({
+                    name,
+                    ...field,
+                }))
+                .filter((f) => f.name !== "fields");
         }
-        
-    
     }, [auth]);
 
     const certFields = useMemo(() => {
-        if(auth) {
+        if (auth) {
             return Object.entries(auth)
-            ?.map(([name, field]: [name: any, field: any]) => ({
-                name,
-                ...field,
-            }))
-            .find((f) => f.name === "fields");
+                ?.map(([name, field]: [name: any, field: any]) => ({
+                    name,
+                    ...field,
+                }))
+                .find((f) => f.name === "fields");
         }
-     
     }, [auth]);
 
     const onValueChange = (value: any, name: any) => {
         const newAuth = JSON.parse(JSON.stringify(auth));
         newAuth[name].value = value;
-
         const dsCP = JSON.parse(JSON.stringify(dataSources));
         const newDataSources = dsCP.map((dataSource: any) => {
             if (dataSource.id === id) {
@@ -59,14 +50,8 @@ export function AuthFields(props: AuthFieldsProps) {
             return dataSource;
         });
 
-        onDsChange(() => newDataSources);
-
-        //localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-
-        //dispatch(setDataSources(newDataSources));
-
+        onDsChange(newDataSources);
         return newDataSources;
-
     };
 
     useEffect(() => {
@@ -77,7 +62,6 @@ export function AuthFields(props: AuthFieldsProps) {
         setActiveFields(certFields);
     }, [fields, setActiveFields]);
 
-    console.log(certFields)
     const onSelectChange = (e: any, name: any) => {
         setIsEditing(() => true);
         const value = e.target.value;
@@ -90,7 +74,6 @@ export function AuthFields(props: AuthFieldsProps) {
     const onSwitchChange = (e: any, name: any) => {
         setIsEditing(() => true);
         const value = e.target.checked;
-
         onValueChange(value, name);
         setTimeout(() => {
             setIsEditing(() => false);
@@ -101,7 +84,6 @@ export function AuthFields(props: AuthFieldsProps) {
         setIsEditing(() => true);
         const value = e.target.value;
         const prevAuth = JSON.parse(JSON.stringify(auth));
-
         const newAuth = {
             ...prevAuth,
             fields: {
@@ -115,11 +97,7 @@ export function AuthFields(props: AuthFieldsProps) {
                 }),
             },
         };
-
         const prevDataSources = JSON.parse(JSON.stringify([...dataSources]));
-
-        console.log(prevDataSources)
-
         const newDataSources = prevDataSources?.map((ds: any) => {
             if (ds.id === id) {
                 ds.auth = newAuth;
@@ -128,19 +106,12 @@ export function AuthFields(props: AuthFieldsProps) {
             return ds;
         });
 
-        console.log(newDataSources)
-
-        //localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-        //dispatch(setDataSources(newDataSources));
-        onDsChange(() => newDataSources);
+        onDsChange(newDataSources);
 
         setTimeout(() => {
             setIsEditing(() => false);
         }, 600);
     };
-
-    console.log(activeFields)
-    console.log(fields)
 
     return (
         <>
@@ -185,7 +156,8 @@ export function AuthFields(props: AuthFieldsProps) {
                         return null;
                     })}
                 <InputCol>
-                    {activeFields?.length > 0 && certFields &&
+                    {activeFields?.length > 0 &&
+                        certFields &&
                         activeFields?.map((val: any, key: any) => {
                             return (
                                 <InputCol key={key}>

--- a/packages/main/views/DataSources/components/AuthFields.tsx
+++ b/packages/main/views/DataSources/components/AuthFields.tsx
@@ -6,38 +6,45 @@ import { SectionHeader } from "./SectionHeader";
 import DOMPurify from "isomorphic-dompurify";
 
 export type AuthFieldsProps = {
-    auth?: any 
-    id?: string 
-    dataSources?: any 
-    onDsChange?: (prev:any) => void
-    fieldErrors?: any
-}
+    auth?: any;
+    id?: string;
+    dataSources?: any;
+    onDsChange?: (prev: any) => void;
+    fieldErrors?: any;
+};
 
 export function AuthFields(props: AuthFieldsProps) {
-   // console.log(props)
+    // console.log(props)
+   
     const { auth, id, dataSources, onDsChange } = props;
-    //const dispatch: any = useDispatch();
-
-    //const dataSources = useSelector((store: any) => store.dataSources);
+    // const dispatch: any = useDispatch();
+    // console.log(auth)
+    // const dataSources = useSelector((store: any) => store.dataSources);
 
     const [activeFields, setActiveFields] = useState<any>([]);
     const [isEditing, setIsEditing] = useState(false);
     const fields = useMemo(() => {
-        return Object.entries(auth)
+        if(auth) {    return Object.entries(auth)
             ?.map(([name, field]: [name: any, field: any]) => ({
                 name,
                 ...field,
             }))
             .filter((f) => f.name !== "fields");
+        }
+        
+    
     }, [auth]);
 
     const certFields = useMemo(() => {
-        return Object.entries(auth)
+        if(auth) {
+            return Object.entries(auth)
             ?.map(([name, field]: [name: any, field: any]) => ({
                 name,
                 ...field,
             }))
             .find((f) => f.name === "fields");
+        }
+     
     }, [auth]);
 
     const onValueChange = (value: any, name: any) => {
@@ -52,22 +59,25 @@ export function AuthFields(props: AuthFieldsProps) {
             return dataSource;
         });
 
-        onDsChange(()=> newDataSources)
+        onDsChange(() => newDataSources);
+
         //localStorage.setItem("dataSources", JSON.stringify(newDataSources));
 
         //dispatch(setDataSources(newDataSources));
 
         return newDataSources;
+
     };
 
     useEffect(() => {
         const certFields = fields
-            .filter((f) => f.form_type === "switch" && !!f?.value)
+            ?.filter((f) => f.form_type === "switch" && !!f?.value)
             ?.filter((f) => !!f.withFields)
             ?.map((m) => m.name);
         setActiveFields(certFields);
     }, [fields, setActiveFields]);
 
+    console.log(certFields)
     const onSelectChange = (e: any, name: any) => {
         setIsEditing(() => true);
         const value = e.target.value;
@@ -107,6 +117,9 @@ export function AuthFields(props: AuthFieldsProps) {
         };
 
         const prevDataSources = JSON.parse(JSON.stringify([...dataSources]));
+
+        console.log(prevDataSources)
+
         const newDataSources = prevDataSources?.map((ds: any) => {
             if (ds.id === id) {
                 ds.auth = newAuth;
@@ -115,13 +128,19 @@ export function AuthFields(props: AuthFieldsProps) {
             return ds;
         });
 
+        console.log(newDataSources)
+
         //localStorage.setItem("dataSources", JSON.stringify(newDataSources));
         //dispatch(setDataSources(newDataSources));
-        onDsChange(()=> newDataSources)
+        onDsChange(() => newDataSources);
+
         setTimeout(() => {
             setIsEditing(() => false);
         }, 600);
     };
+
+    console.log(activeFields)
+    console.log(fields)
 
     return (
         <>
@@ -166,17 +185,17 @@ export function AuthFields(props: AuthFieldsProps) {
                         return null;
                     })}
                 <InputCol>
-                    {activeFields &&
-                        activeFields.map((val: any, key: any) => {
+                    {activeFields?.length > 0 && certFields &&
+                        activeFields?.map((val: any, key: any) => {
                             return (
                                 <InputCol key={key}>
                                     {certFields[val] &&
                                         certFields[val]?.map(
                                             (cert: any, y: any) => {
                                                 if (
-                                                    cert.form_type ===
+                                                    cert?.form_type ===
                                                         "input" ||
-                                                    cert.form_type ===
+                                                    cert?.form_type ===
                                                         "password"
                                                 ) {
                                                     return (
@@ -206,7 +225,7 @@ export function AuthFields(props: AuthFieldsProps) {
                                                 }
 
                                                 if (
-                                                    cert.form_type ===
+                                                    cert?.form_type ===
                                                     "textarea"
                                                 ) {
                                                     return (

--- a/packages/main/views/DataSources/components/ConfirmSave.tsx
+++ b/packages/main/views/DataSources/components/ConfirmSave.tsx
@@ -1,22 +1,20 @@
-import { cx } from '@emotion/css'
-import { QrynTheme } from '@ui/theme/types';
+import { cx } from "@emotion/css";
+import { QrynTheme } from "@ui/theme/types";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import { confirmSaveLoaderCont, confirmSaveLoaderIcon } from "./header.styles";
 
 export type ConfirmSaveProps = {
-    setIsSaved : (boolean) => void
-    theme: QrynTheme
-}
+    setIsSaved: (boolean) => void;
+    theme: QrynTheme;
+};
 
 export const ConfirmSave = ({ setIsSaved, theme }: ConfirmSaveProps) => {
-
     return (
         <div
             className={cx(confirmSaveLoaderCont(theme))}
             onClick={() => setIsSaved(false)}
         >
             <CheckCircleIcon className={cx(confirmSaveLoaderIcon)} />{" "}
-            <span>Saved</span>
         </div>
     );
 };

--- a/packages/main/views/DataSources/components/ConfirmSave.tsx
+++ b/packages/main/views/DataSources/components/ConfirmSave.tsx
@@ -1,0 +1,22 @@
+import { cx } from '@emotion/css'
+import { QrynTheme } from '@ui/theme/types';
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import { confirmSaveLoaderCont, confirmSaveLoaderIcon } from "./header.styles";
+
+export type ConfirmSaveProps = {
+    setIsSaved : (boolean) => void
+    theme: QrynTheme
+}
+
+export const ConfirmSave = ({ setIsSaved, theme }: ConfirmSaveProps) => {
+
+    return (
+        <div
+            className={cx(confirmSaveLoaderCont(theme))}
+            onClick={() => setIsSaved(false)}
+        >
+            <CheckCircleIcon className={cx(confirmSaveLoaderIcon)} />{" "}
+            <span>Saved</span>
+        </div>
+    );
+};

--- a/packages/main/views/DataSources/components/DataSourceHeaders.tsx
+++ b/packages/main/views/DataSources/components/DataSourceHeaders.tsx
@@ -1,7 +1,6 @@
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 import { nanoid } from "nanoid";
 import { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
 import setDataSources from "../store/setDataSources";
 import { InputCol, InputGroup, Label } from "../styles";
 import { Field } from "../ui";
@@ -9,13 +8,25 @@ import { SectionHeader } from "./SectionHeader";
 import DOMPurify from "isomorphic-dompurify";
 import { Switch } from "@mui/material";
 
-export const DataSourceHeaders = (props: any) => {
-    const dispatch: any = useDispatch();
+type HeaderEntry = {
+    id: string
+    header: string
+    value: string  
+}
+type DataSourceHadersProps = {
+    id: string;
+    cors?: boolean 
+    headers: HeaderEntry[]
+    dataSources: any
+    onDsChange: (prev:any) => void 
+}
 
-    const dataSources = useSelector((store: any) => store.dataSources);
+export const DataSourceHeaders = (props: DataSourceHadersProps) => {
+
+   // const dataSources = useSelector((store: any) => store.dataSources);
     const [editing, setEditing] = useState(false);
 
-    const { headers, id } = props;
+    const { headers, id, onDsChange, dataSources } = props;
     const [cors, setCors] = useState(props?.cors || false);
 
     const onCorsChange = (e: any) => {
@@ -27,9 +38,11 @@ export const DataSourceHeaders = (props: any) => {
             }
             return ds;
         });
+
         setCors(() => value);
-        localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-        dispatch(setDataSources(newDataSources));
+        onDsChange(()=>newDataSources)
+        // localStorage.setItem("dataSources", JSON.stringify(newDataSources));
+       // dispatch(setDataSources(newDataSources));
     };
 
     const onChange = (e: any, headerId: any, name: any) => {
@@ -53,8 +66,10 @@ export const DataSourceHeaders = (props: any) => {
             return ds;
         });
 
-        localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-        dispatch(setDataSources(newDataSources));
+      //  localStorage.setItem("dataSources", JSON.stringify(newDataSources));
+      //  dispatch(setDataSources(newDataSources));
+
+      onDsChange(()=>newDataSources)
         setTimeout(() => {
             setEditing(() => false);
         }, 800);
@@ -84,9 +99,9 @@ export const DataSourceHeaders = (props: any) => {
                 }
                 return ds;
             });
-
-            localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-            dispatch(setDataSources(newDataSources));
+            onDsChange(()=> newDataSources)
+           // localStorage.setItem("dataSources", JSON.stringify(newDataSources));
+           // dispatch(setDataSources(newDataSources));
         }
     };
 

--- a/packages/main/views/DataSources/components/DataSourceHeaders.tsx
+++ b/packages/main/views/DataSources/components/DataSourceHeaders.tsx
@@ -1,7 +1,7 @@
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 import { nanoid } from "nanoid";
 import { useState } from "react";
-import setDataSources from "../store/setDataSources";
+//import setDataSources from "../store/setDataSources";
 import { InputCol, InputGroup, Label } from "../styles";
 import { Field } from "../ui";
 import { SectionHeader } from "./SectionHeader";
@@ -117,8 +117,10 @@ export const DataSourceHeaders = (props: DataSourceHadersProps) => {
             return ds;
         });
 
-        localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-        dispatch(setDataSources(newDataSources));
+        onDsChange(()=> newDataSources)
+
+       // localStorage.setItem("dataSources", JSON.stringify(newDataSources));
+       // dispatch(setDataSources(newDataSources));
     };
 
     return (

--- a/packages/main/views/DataSources/components/DataSourceHeaders.tsx
+++ b/packages/main/views/DataSources/components/DataSourceHeaders.tsx
@@ -9,21 +9,19 @@ import DOMPurify from "isomorphic-dompurify";
 import { Switch } from "@mui/material";
 
 type HeaderEntry = {
-    id: string
-    header: string
-    value: string  
-}
+    id: string;
+    header: string;
+    value: string;
+};
 type DataSourceHadersProps = {
     id: string;
-    cors?: boolean 
-    headers: HeaderEntry[]
-    dataSources: any
-    onDsChange: (prev:any) => void 
-}
+    cors?: boolean;
+    headers: HeaderEntry[];
+    dataSources: any;
+    onDsChange: (prev: any) => void;
+};
 
 export const DataSourceHeaders = (props: DataSourceHadersProps) => {
-
-   // const dataSources = useSelector((store: any) => store.dataSources);
     const [editing, setEditing] = useState(false);
 
     const { headers, id, onDsChange, dataSources } = props;
@@ -40,9 +38,7 @@ export const DataSourceHeaders = (props: DataSourceHadersProps) => {
         });
 
         setCors(() => value);
-        onDsChange(()=>newDataSources)
-        // localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-       // dispatch(setDataSources(newDataSources));
+        onDsChange(newDataSources);
     };
 
     const onChange = (e: any, headerId: any, name: any) => {
@@ -66,10 +62,7 @@ export const DataSourceHeaders = (props: DataSourceHadersProps) => {
             return ds;
         });
 
-      //  localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-      //  dispatch(setDataSources(newDataSources));
-
-      onDsChange(()=>newDataSources)
+        onDsChange(newDataSources);
         setTimeout(() => {
             setEditing(() => false);
         }, 800);
@@ -99,9 +92,7 @@ export const DataSourceHeaders = (props: DataSourceHadersProps) => {
                 }
                 return ds;
             });
-            onDsChange(()=> newDataSources)
-           // localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-           // dispatch(setDataSources(newDataSources));
+            onDsChange(newDataSources);
         }
     };
 
@@ -117,10 +108,7 @@ export const DataSourceHeaders = (props: DataSourceHadersProps) => {
             return ds;
         });
 
-        onDsChange(()=> newDataSources)
-
-       // localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-       // dispatch(setDataSources(newDataSources));
+        onDsChange(newDataSources);
     };
 
     return (

--- a/packages/main/views/DataSources/components/DataSourcesFiller.tsx
+++ b/packages/main/views/DataSources/components/DataSourcesFiller.tsx
@@ -57,7 +57,7 @@ export const urlSchema = z.string().url()
 
 const DEFAULT_URL = window.location.origin
 
-export const DataSourcesFiller = (props: any) => {
+export const DataSourcesFiller = () => {
 
     const [url, setUrl] = useState("");
     const [user, setUser] = useState("");

--- a/packages/main/views/DataSources/components/FieldErrors.tsx
+++ b/packages/main/views/DataSources/components/FieldErrors.tsx
@@ -1,0 +1,30 @@
+import { InputErrorWarning } from "./InputErrorWarning";
+
+export const FIELD_ERROR_TEXT = {
+    protocol: "mixed_content",
+    url: "complete_url",
+};
+
+type FieldError = Record<keyof typeof FIELD_ERROR_TEXT, boolean>;
+
+export type FieldErrorProps = {
+    fieldErrors?: FieldError;
+};
+
+export const mapErrors = (fieldErrors: FieldError) => {
+    return Object.keys(fieldErrors)
+        .map((error) => error)
+        .filter((f) => Boolean(fieldErrors[f]));
+};
+
+export const FieldErrors = (props: FieldErrorProps) => {
+    const { fieldErrors } = props;
+    if (!fieldErrors) return <></>;
+    return (
+        <>
+            {mapErrors(fieldErrors)?.map((error, key) => (
+                <InputErrorWarning key={key} error={FIELD_ERROR_TEXT[error]} />
+            ))}
+        </>
+    );
+};

--- a/packages/main/views/DataSources/components/Header.tsx
+++ b/packages/main/views/DataSources/components/Header.tsx
@@ -9,14 +9,16 @@ import useTheme from "@ui/theme/useTheme"
 export interface HeaderProps {
     title: string;
     datasource?: any;
+    onSave?: () => void
 }
 
 export function Header(props: HeaderProps) {
+
     const navigate = useNavigate();
     const theme = useTheme();
     const urlLocation = useSelector((store: any) => store.urlLocation);
     const dispatch: any = useDispatch();
-    const { title } = props;
+    const { title, onSave } = props;
     const isDsSaved = useSelector((store: any) => store.isDsSaved);
     const buttonMessage = useMemo(() => {
         if (isDsSaved) {
@@ -61,7 +63,14 @@ export function Header(props: HeaderProps) {
             </div>
             </div>
             <Button
-                value={DOMPurify.sanitize(buttonMessage)}
+                value={DOMPurify.sanitize("Save")}
+                onClick={onSave}
+                editing={true}
+                primary={isDsSaved}
+            />
+
+            <Button
+                value={DOMPurify.sanitize("Back")}
                 onClick={backOne}
                 editing={true}
                 primary={isDsSaved}

--- a/packages/main/views/DataSources/components/Header.tsx
+++ b/packages/main/views/DataSources/components/Header.tsx
@@ -1,71 +1,73 @@
-import { useMemo } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
-
-import setIsDatasourceSaved from "../store/setIsDataSourceSaved";
 import { Button, QrynLogo } from "../ui";
 import DOMPurify from "isomorphic-dompurify";
-import useTheme from "@ui/theme/useTheme"
+import useTheme from "@ui/theme/useTheme";
 import { useStoreSettings } from "../hooks/useStoreSettings";
+import { createAlert } from "@ui/store/actions";
+
 export interface HeaderProps {
     title: string;
     datasource?: any;
-   
 }
 
 export function Header(props: HeaderProps) {
-    const { storeDataSources} = useStoreSettings()
+    const dispatch:any = useDispatch()
+    const { storeDataSources, setSettings } = useStoreSettings();
+    const datasources = useSelector((store: any) => store.dataSources);
     const navigate = useNavigate();
     const theme = useTheme();
-    const urlLocation = useSelector((store: any) => store.urlLocation);
-    const dispatch: any = useDispatch();
     const { title } = props;
     const isDsSaved = useSelector((store: any) => store.isDsSaved);
-    const buttonMessage = useMemo(() => {
-        if (isDsSaved) {
-            return "Save";
-        }
-        return "Back";
-    }, [isDsSaved]);
+
+    const onSave = () => {
+        storeDataSources()
+        dispatch(createAlert({
+            type:'success',
+            message: "Data Source Setting Saved SuccessFully",
+
+        }))
+    }
 
     const backOne = () => {
-        let isLocation = urlLocation?.length > 0;
-        dispatch(setIsDatasourceSaved(false));
-        if (
-            (isLocation || buttonMessage === "Back") &&
-            title !== "DataSources"
-        ) {
             navigate(-1);
-        } else {
-            navigate("");
-        }
+    };
+
+    const cancelAction = () => {
+        setSettings(datasources);
     };
 
     return (
         <div className="ds-header">
             <div style={{ display: "flex", alignItems: "center" }}>
-                <div style={{display:'flex', flexDirection:'column'}}>
-                <div style={{display:'flex'}}>
-                <QrynLogo />
-                <h1>{title}</h1>
-                </div>
-               
-                <p
+                <div style={{ display: "flex", flexDirection: "column" }}>
+                    <div style={{ display: "flex" }}>
+                        <QrynLogo />
+                        <h1>{title}</h1>
+                    </div>
+
+                    <p
                         style={{
                             color: theme.contrast,
                             fontSize: "10px",
-                            marginTop:'5px',
-                            marginLeft:'10px',
-                            opacity:'.5',
+                            marginTop: "5px",
+                            marginLeft: "10px",
+                            opacity: ".5",
                         }}
                     >
                         v{import.meta.env.VITE_APP_VERSION}
                     </p>
-            </div>
+                </div>
             </div>
             <Button
                 value={DOMPurify.sanitize("Save")}
-                onClick={storeDataSources}
+                onClick={onSave}
+                editing={true}
+                primary={isDsSaved}
+            />
+            <Button
+                value={DOMPurify.sanitize("Cancel")}
+                onClick={cancelAction}
                 editing={true}
                 primary={isDsSaved}
             />

--- a/packages/main/views/DataSources/components/Header.tsx
+++ b/packages/main/views/DataSources/components/Header.tsx
@@ -6,19 +6,20 @@ import setIsDatasourceSaved from "../store/setIsDataSourceSaved";
 import { Button, QrynLogo } from "../ui";
 import DOMPurify from "isomorphic-dompurify";
 import useTheme from "@ui/theme/useTheme"
+import { useStoreSettings } from "../hooks/useStoreSettings";
 export interface HeaderProps {
     title: string;
     datasource?: any;
-    onSave?: () => void
+   
 }
 
 export function Header(props: HeaderProps) {
-
+    const { storeDataSources} = useStoreSettings()
     const navigate = useNavigate();
     const theme = useTheme();
     const urlLocation = useSelector((store: any) => store.urlLocation);
     const dispatch: any = useDispatch();
-    const { title, onSave } = props;
+    const { title } = props;
     const isDsSaved = useSelector((store: any) => store.isDsSaved);
     const buttonMessage = useMemo(() => {
         if (isDsSaved) {
@@ -64,7 +65,7 @@ export function Header(props: HeaderProps) {
             </div>
             <Button
                 value={DOMPurify.sanitize("Save")}
-                onClick={onSave}
+                onClick={storeDataSources}
                 editing={true}
                 primary={isDsSaved}
             />

--- a/packages/main/views/DataSources/components/Header.tsx
+++ b/packages/main/views/DataSources/components/Header.tsx
@@ -1,10 +1,8 @@
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { Button, QrynLogo } from "../ui";
 import DOMPurify from "isomorphic-dompurify";
 import useTheme from "@ui/theme/useTheme";
-import { useStoreSettings } from "../hooks/useStoreSettings";
-import { createAlert } from "@ui/store/actions";
 
 export interface HeaderProps {
     title: string;
@@ -12,29 +10,13 @@ export interface HeaderProps {
 }
 
 export function Header(props: HeaderProps) {
-    const dispatch:any = useDispatch()
-    const { storeDataSources, setSettings } = useStoreSettings();
-    const datasources = useSelector((store: any) => store.dataSources);
     const navigate = useNavigate();
     const theme = useTheme();
     const { title } = props;
     const isDsSaved = useSelector((store: any) => store.isDsSaved);
 
-    const onSave = () => {
-        storeDataSources()
-        dispatch(createAlert({
-            type:'success',
-            message: "Data Source Setting Saved SuccessFully",
-
-        }))
-    }
-
     const backOne = () => {
-            navigate(-1);
-    };
-
-    const cancelAction = () => {
-        setSettings(datasources);
+        navigate(-1);
     };
 
     return (
@@ -59,18 +41,6 @@ export function Header(props: HeaderProps) {
                     </p>
                 </div>
             </div>
-            <Button
-                value={DOMPurify.sanitize("Save")}
-                onClick={onSave}
-                editing={true}
-                primary={isDsSaved}
-            />
-            <Button
-                value={DOMPurify.sanitize("Cancel")}
-                onClick={cancelAction}
-                editing={true}
-                primary={isDsSaved}
-            />
 
             <Button
                 value={DOMPurify.sanitize("Back")}

--- a/packages/main/views/DataSources/components/InputErrorWarning.tsx
+++ b/packages/main/views/DataSources/components/InputErrorWarning.tsx
@@ -1,0 +1,22 @@
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import { cx } from '@emotion/css'
+import { confirmSaveLoaderIcon, inputErrorCont } from "./header.styles";
+
+export const WARNING_ERRORS = {
+    mixed_content: "Insecure Mixed Content. Mixing HTTP and HTTPS is insecure and is not supported.",
+    complete_url: "Please complete API URL"
+}
+
+export type InputErrorWarningProps = {
+    error:  keyof typeof WARNING_ERRORS
+}
+
+export const InputErrorWarning = (props: InputErrorWarningProps) => {
+    const {error} = props 
+    return (
+        <div className={cx(inputErrorCont)}>
+            <ErrorOutlineIcon className={cx(confirmSaveLoaderIcon)} />{" "}
+            <span>{WARNING_ERRORS[error]}</span>
+        </div>
+    );
+};

--- a/packages/main/views/DataSources/components/LinkedField.tsx
+++ b/packages/main/views/DataSources/components/LinkedField.tsx
@@ -2,8 +2,8 @@ import { LinkFieldsGroup, InputCol } from "../styles";
 import { Field, QrynSwitch, Select } from "../ui";
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 import { useMemo } from "react";
-import DOMPurify from 'isomorphic-dompurify'
-export const LinkedField = (props:any) => {
+import DOMPurify from "isomorphic-dompurify";
+export const LinkedField = (props: any) => {
     const {
         id,
         name,
@@ -15,37 +15,32 @@ export const LinkedField = (props:any) => {
         dataSourceId,
         fieldEditing,
         dataSources,
-        dsChange
-
+        dsChange,
     } = props;
 
-    // const dispatch: any = useDispatch();
-
-    // const dataSources = useSelector((store:any) => store.dataSources);
-
     const dataSourcesOpts = useMemo(() => {
-        return dataSources.map((m:any) => ({
+        return dataSources?.map((m: any) => ({
             name: m.name,
             value: m.id,
         }));
     }, [dataSources]);
 
-    const onLinkedFieldChange = (prop:any, value:any) => {
-        fieldEditing()
+    const onLinkedFieldChange = (prop: any, value: any) => {
+        fieldEditing();
 
         const prevDataSources = JSON.parse(JSON.stringify(dataSources));
-        const prevDs = prevDataSources.find((f:any) => f.id === dataSourceId);
+        const prevDs = prevDataSources.find((f: any) => f.id === dataSourceId);
 
         const prevLinked = prevDs["linkedFields"];
 
-        const newLinked = prevLinked.map((m:any) => {
+        const newLinked = prevLinked?.map((m: any) => {
             if (m.id === id) {
                 return { ...m, [prop]: value };
             }
             return m;
         });
 
-        return prevDataSources.map((m:any) => {
+        return prevDataSources?.map((m: any) => {
             if (m.id === dataSourceId) {
                 return { ...m, linkedFields: newLinked };
             }
@@ -54,47 +49,35 @@ export const LinkedField = (props:any) => {
     };
 
     const onLinkedFieldRemove = () => {
-        fieldEditing()
+        fieldEditing();
         const prevDataSources = JSON.parse(JSON.stringify(dataSources));
-        const prevDs = prevDataSources.find((f:any) => f.id === dataSourceId);
+        const prevDs = prevDataSources?.find((f: any) => f.id === dataSourceId);
         const prevLinked = prevDs["linkedFields"];
-        const newLinked = prevLinked.filter((f:any) => f.id !== id);
+        const newLinked = prevLinked?.filter((f: any) => f.id !== id);
 
-        const newDataSources = prevDataSources.map((m:any) => {
+        const newDataSources = prevDataSources?.map((m: any) => {
             if (m.id === dataSourceId) {
                 return { ...m, linkedFields: [...newLinked] };
             }
             return m;
         });
 
-       // localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-       // dispatch(setDataSources(newDataSources));
-       dsChange(()=> newDataSources)
+        dsChange(newDataSources);
     };
 
-    const onChange = (e:any, name:any) => {
-        fieldEditing()
+    const onChange = (e: any, name: any) => {
+        fieldEditing();
         const value = e.target.value;
-        // setNewDataSources
-
         const newVal = onLinkedFieldChange(name, value);
-
-        dsChange(()=> newVal)
-
-    //    localStorage.setItem("dataSources", JSON.stringify(newVal));
-
-    //    dispatch(setDataSources(newVal));
+        dsChange(newVal);
     };
 
-    const onSwitchChange = (e:any, name:any) => {
-        fieldEditing()
+    const onSwitchChange = (e: any, name: any) => {
+        fieldEditing();
         const value = Boolean(e.target.checked);
 
         const newVal = onLinkedFieldChange(name, value);
-        dsChange(()=> newVal)
-
-      //  localStorage.setItem("dataSources", JSON.stringify(newVal));
-      //  dispatch(setDataSources(newVal));
+        dsChange(newVal);
     };
 
     return (
@@ -103,26 +86,26 @@ export const LinkedField = (props:any) => {
                 <Field
                     value={DOMPurify.sanitize(name)}
                     label={"Name"}
-                    onChange={(e:any) => onChange(e, "name")}
+                    onChange={(e: any) => onChange(e, "name")}
                 />
 
                 <Field
                     value={DOMPurify.sanitize(regex)}
                     label={"Regex"}
-                    onChange={(e:any) => onChange(e, "regex")}
+                    onChange={(e: any) => onChange(e, "regex")}
                 />
 
                 <Field
                     value={DOMPurify.sanitize(urlLabel)}
                     label={"URL Label"}
-                    onChange={(e:any) => onChange(e, "urlLabel")}
+                    onChange={(e: any) => onChange(e, "urlLabel")}
                 />
 
                 <DeleteOutlineOutlinedIcon
                     onClick={onLinkedFieldRemove}
                     fontSize={"small"}
                     style={{
-                        marginLeft:'10px',
+                        marginLeft: "10px",
                         cursor: "pointer",
                         display: locked ? "none" : "inline-block",
                     }}
@@ -133,7 +116,7 @@ export const LinkedField = (props:any) => {
                 <QrynSwitch
                     value={internalLink}
                     label={"Internal Link"}
-                    onChange={(e:any) => onSwitchChange(e, "internalLink")}
+                    onChange={(e: any) => onSwitchChange(e, "internalLink")}
                 />
 
                 <Select
@@ -141,7 +124,7 @@ export const LinkedField = (props:any) => {
                     value={DOMPurify.sanitize(linkType)}
                     opts={dataSourcesOpts}
                     selectType={"linkedField"}
-                    onChange={(e:any) => onChange(e, "linkID")}
+                    onChange={(e: any) => onChange(e, "linkID")}
                 />
             </InputCol>
         </LinkFieldsGroup>

--- a/packages/main/views/DataSources/components/LinkedField.tsx
+++ b/packages/main/views/DataSources/components/LinkedField.tsx
@@ -1,8 +1,6 @@
-import { useDispatch, useSelector } from "react-redux";
 import { LinkFieldsGroup, InputCol } from "../styles";
 import { Field, QrynSwitch, Select } from "../ui";
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
-import setDataSources from "../store/setDataSources";
 import { useMemo } from "react";
 import DOMPurify from 'isomorphic-dompurify'
 export const LinkedField = (props:any) => {
@@ -15,12 +13,15 @@ export const LinkedField = (props:any) => {
         linkType,
         locked,
         dataSourceId,
-        fieldEditing
+        fieldEditing,
+        dataSources,
+        dsChange
+
     } = props;
 
-    const dispatch: any = useDispatch();
+    // const dispatch: any = useDispatch();
 
-    const dataSources = useSelector((store:any) => store.dataSources);
+    // const dataSources = useSelector((store:any) => store.dataSources);
 
     const dataSourcesOpts = useMemo(() => {
         return dataSources.map((m:any) => ({
@@ -52,7 +53,7 @@ export const LinkedField = (props:any) => {
         });
     };
 
-    const onLinkedFieldRemove = (e:any) => {
+    const onLinkedFieldRemove = () => {
         fieldEditing()
         const prevDataSources = JSON.parse(JSON.stringify(dataSources));
         const prevDs = prevDataSources.find((f:any) => f.id === dataSourceId);
@@ -66,8 +67,9 @@ export const LinkedField = (props:any) => {
             return m;
         });
 
-        localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-        dispatch(setDataSources(newDataSources));
+       // localStorage.setItem("dataSources", JSON.stringify(newDataSources));
+       // dispatch(setDataSources(newDataSources));
+       dsChange(()=> newDataSources)
     };
 
     const onChange = (e:any, name:any) => {
@@ -77,9 +79,11 @@ export const LinkedField = (props:any) => {
 
         const newVal = onLinkedFieldChange(name, value);
 
-        localStorage.setItem("dataSources", JSON.stringify(newVal));
+        dsChange(()=> newVal)
 
-        dispatch(setDataSources(newVal));
+    //    localStorage.setItem("dataSources", JSON.stringify(newVal));
+
+    //    dispatch(setDataSources(newVal));
     };
 
     const onSwitchChange = (e:any, name:any) => {
@@ -87,8 +91,10 @@ export const LinkedField = (props:any) => {
         const value = Boolean(e.target.checked);
 
         const newVal = onLinkedFieldChange(name, value);
-        localStorage.setItem("dataSources", JSON.stringify(newVal));
-        dispatch(setDataSources(newVal));
+        dsChange(()=> newVal)
+
+      //  localStorage.setItem("dataSources", JSON.stringify(newVal));
+      //  dispatch(setDataSources(newVal));
     };
 
     return (

--- a/packages/main/views/DataSources/components/LinkedFields.tsx
+++ b/packages/main/views/DataSources/components/LinkedFields.tsx
@@ -1,17 +1,25 @@
 import { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+//import { useDispatch, useSelector } from "react-redux";
 import { LinkedFieldItem } from "../classes/LinkedFieldItem";
-import setDataSources from "../store/setDataSources";
+//import setDataSources from "../store/setDataSources";
 import { InputCont } from "../styles";
 import { LinkedField } from "./LinkedField";
 import { SectionHeader } from "./SectionHeader";
 
-export const LinkedFields = (props: any) => {
-    const { linkedFields, name, id } = props;
+export type LinkedFieldsProps = {
+    id: string;
+    name: string;
+    linkedFields: any;
+    dataSources: any;
+    onDsChange: (prev:any) => void
+}
 
-    const dataSources = useSelector((store: any) => store.dataSources);
+export const LinkedFields = (props: LinkedFieldsProps) => {
+    const { linkedFields, name, id, dataSources, onDsChange } = props;
 
-    const dispatch: any = useDispatch();
+    //const dataSources = useSelector((store: any) => store.dataSources);
+
+  //  const dispatch: any = useDispatch();
     const [isEditing, setIsEditing] = useState(false);
 
     const onAddLinkedField = () => {
@@ -35,8 +43,10 @@ export const LinkedFields = (props: any) => {
             return m;
         });
 
-        localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-        dispatch(setDataSources(newDataSources));
+        onDsChange( () => newDataSources)
+
+       // localStorage.setItem("dataSources", JSON.stringify(newDataSources));
+       // dispatch(setDataSources(newDataSources));
     };
 
     const fieldEditing = () => {

--- a/packages/main/views/DataSources/components/LinkedFields.tsx
+++ b/packages/main/views/DataSources/components/LinkedFields.tsx
@@ -75,6 +75,8 @@ export const LinkedFields = (props: LinkedFieldsProps) => {
                             dataSourceId={id}
                             locked={false}
                             fieldEditing={fieldEditing}
+                            dsChange={onDsChange}
+                            dataSources={dataSources}
                         />
                     ))}
                 </InputCont>

--- a/packages/main/views/DataSources/components/LinkedFields.tsx
+++ b/packages/main/views/DataSources/components/LinkedFields.tsx
@@ -11,28 +11,19 @@ export type LinkedFieldsProps = {
     name: string;
     linkedFields: any;
     dataSources: any;
-    onDsChange: (prev:any) => void
-}
+    onDsChange: (prev: any) => void;
+};
 
 export const LinkedFields = (props: LinkedFieldsProps) => {
     const { linkedFields, name, id, dataSources, onDsChange } = props;
-
-    //const dataSources = useSelector((store: any) => store.dataSources);
-
-  //  const dispatch: any = useDispatch();
     const [isEditing, setIsEditing] = useState(false);
-
     const onAddLinkedField = () => {
-        // modify to add linked filed into datasources => linkedFields
         const newLinked = new LinkedFieldItem();
         newLinked.dataSource = name;
         newLinked.create();
         const linkedClone = JSON.parse(JSON.stringify(linkedFields));
-
         const newList = [...linkedClone, { ...newLinked }];
-
         const prevDataSources = JSON.parse(JSON.stringify(dataSources));
-
         const newDataSources = prevDataSources?.map((m: any) => {
             if (m.id === id) {
                 return {
@@ -43,10 +34,7 @@ export const LinkedFields = (props: LinkedFieldsProps) => {
             return m;
         });
 
-        onDsChange( () => newDataSources)
-
-       // localStorage.setItem("dataSources", JSON.stringify(newDataSources));
-       // dispatch(setDataSources(newDataSources));
+        onDsChange(newDataSources);
     };
 
     const fieldEditing = () => {
@@ -68,17 +56,18 @@ export const LinkedFields = (props: LinkedFieldsProps) => {
                 />
 
                 <InputCont>
-                    {linkedFields?.map((val: any, key: any) => (
-                        <LinkedField
-                            key={key}
-                            {...val}
-                            dataSourceId={id}
-                            locked={false}
-                            fieldEditing={fieldEditing}
-                            dsChange={onDsChange}
-                            dataSources={dataSources}
-                        />
-                    ))}
+                    {linkedFields &&
+                        linkedFields?.map((val: any, key: any) => (
+                            <LinkedField
+                                key={key}
+                                {...val}
+                                dataSourceId={id}
+                                locked={false}
+                                fieldEditing={fieldEditing}
+                                dsChange={onDsChange}
+                                dataSources={dataSources}
+                            />
+                        ))}
                 </InputCont>
             </>
         );

--- a/packages/main/views/DataSources/components/SectionHeader.tsx
+++ b/packages/main/views/DataSources/components/SectionHeader.tsx
@@ -1,11 +1,9 @@
 import { SettingsTitle } from "../styles";
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
-import CachedOutlinedIcon from "@mui/icons-material/CachedOutlined";
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import setIsDatasourceSaved from "../store/setIsDataSourceSaved";
 import useTheme from "@ui/theme/useTheme";
-import { SavingLoader } from "./header.styles";
 import { ConfirmSave } from "./ConfirmSave";
 import { FieldErrors } from "./FieldErrors";
 import { Tooltip } from "@mui/material";
@@ -63,14 +61,6 @@ export function SectionHeader(props: SectionHeaderProps) {
             </div>
 
             <div className="edit-buttons">
-                {isEditing && (
-                    <div className={SavingLoader}>
-                        <CachedOutlinedIcon
-                            style={{ height: "13px", width: "13px" }}
-                        />{" "}
-                        Saving ...
-                    </div>
-                )}
 
                 <FieldErrors fieldErrors={fieldErrors} />
 

--- a/packages/main/views/DataSources/components/SectionHeader.tsx
+++ b/packages/main/views/DataSources/components/SectionHeader.tsx
@@ -82,10 +82,10 @@ const InputErrorWarning = ({ errorText }: { errorText: string }) => {
 
 export type SectionHeaderProps = {
     isEditing?: boolean
-    isEdit: boolean 
-    isAdd:boolean 
-    title: string
-    fieldErrors: any 
+    isEdit?: boolean 
+    isAdd?:boolean 
+    title?: string
+    fieldErrors?: any 
     onClickAdd?: () => void 
 }
 

--- a/packages/main/views/DataSources/components/SectionHeader.tsx
+++ b/packages/main/views/DataSources/components/SectionHeader.tsx
@@ -17,7 +17,6 @@ export type SectionHeaderProps = {
     title?: string;
     fieldErrors?: any;
     onClickAdd?: (e?:any) => void;
-    saveSettings?: () => void
 };
 
 export function SectionHeader(props: SectionHeaderProps) {

--- a/packages/main/views/DataSources/components/SectionHeader.tsx
+++ b/packages/main/views/DataSources/components/SectionHeader.tsx
@@ -1,98 +1,37 @@
 import { SettingsTitle } from "../styles";
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import CachedOutlinedIcon from "@mui/icons-material/CachedOutlined";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import { cx, css } from "@emotion/css";
+
+
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import setIsDatasourceSaved from "../store/setIsDataSourceSaved";
-import useTheme from "@ui/theme/useTheme"
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
-
-const confirmSaveLoaderIcon = css`
-    height: 12px !important;
-    width: 12px !important;
-    color: white;
-    margin: 0px 4px;
-`;
-
-const confirmSaveLoaderCont = (theme: any) => css`
-    display: flex;
-    align-items: center;
-    background: ${theme.primary};
-    color: white;
-    font-size: 11px;
-    padding: 4px;
-    border-radius: 3px;
-    margin-right: 10px;
-    cursor: pointer;
-    span {
-        margin-right: 4px;
-        font-weight: bold;
-    }
-`;
-
-const inputErrorCont = css`
-    display: flex;
-    align-items: center;
-    background: #b62c14;
-    color: white;
-    font-size: 12px;
-    padding: 4px;
-    border-radius: 3px;
-    margin-right: 10px;
-    cursor: pointer;
-    span {
-        margin-right: 4px;
-        font-weight: bold;
-    }
-`;
-
-const SavingLoader = css`
-    display: flex;
-    align-items: center;
-    font-size: 12px;
-    &.loading-icon {
-        height: 14px;
-        width: 14px;
-    }
-`;
-
-const ConfirmSave = ({ setIsSaved }: { setIsSaved: any }) => {
-    const theme = useTheme();
-    return (
-        <div
-            className={cx(confirmSaveLoaderCont(theme))}
-            onClick={(e) => setIsSaved(false)}
-        >
-            <CheckCircleIcon className={cx(confirmSaveLoaderIcon)} />{" "}
-            <span>Saved</span>
-        </div>
-    );
-};
-
-const InputErrorWarning = ({ errorText }: { errorText: string }) => {
-    return (
-        <div className={cx(inputErrorCont)}>
-            <ErrorOutlineIcon className={cx(confirmSaveLoaderIcon)} />{" "}
-            <span>{errorText}</span>
-        </div>
-    );
-};
-
+import useTheme from "@ui/theme/useTheme";
+import { SavingLoader } from "./header.styles";
+import { ConfirmSave } from "./ConfirmSave";
+import { FieldErrors } from "./FieldErrors";
 export type SectionHeaderProps = {
-    isEditing?: boolean
-    isEdit?: boolean 
-    isAdd?:boolean 
-    title?: string
-    fieldErrors?: any 
-    onClickAdd?: () => void 
-}
+    isEditing?: boolean;
+    isEdit?: boolean;
+    isAdd?: boolean;
+    title?: string;
+    fieldErrors?: any;
+    onClickAdd?: (e?:any) => void;
+    saveSettings?: () => void
+};
 
 export function SectionHeader(props: SectionHeaderProps) {
     const { onClickAdd, isAdd, title, isEditing, fieldErrors } = props;
-   const dispatch: any = useDispatch();
+    const theme = useTheme()
+    const dispatch: any = useDispatch();
     const [isSaved, setIsSaved] = useState(false);
+
+
+
+    // here should go the save settings dialog
+
+    // we should add the dialog in here or a switch to alternate autosave 
+    // with save with confirmation
 
     useEffect(() => {
         if (isEditing) {
@@ -109,34 +48,12 @@ export function SectionHeader(props: SectionHeaderProps) {
         return () => {
             setIsSaved(false);
         };
-          
     }, [isEditing]);
 
     return (
         <SettingsTitle>
             {title}
-            <div className="edit-buttons">
-                {isEditing && (
-                    <div className={SavingLoader}>
-                        <CachedOutlinedIcon
-                            style={{ height: "13px", width: "13px" }}
-                        />{" "}
-                        Saving ...
-                    </div>
-                )}
-                {fieldErrors?.protocol && (
-                    <InputErrorWarning
-                        errorText={
-                            "Insecure Mixed Content. Mixing HTTP and HTTPS is insecure and is not supported."
-                        }
-                    />
-                )}
-                {fieldErrors?.url && (
-                    <InputErrorWarning errorText={"Please complete API URL"} />
-                )}
-                {isSaved && <ConfirmSave setIsSaved={setIsSaved} />}
-
-                {isAdd && (
+            {isAdd && (
                     <>
                         <AddOutlinedIcon
                             fontSize={"small"}
@@ -148,6 +65,27 @@ export function SectionHeader(props: SectionHeaderProps) {
                         />
                     </>
                 )}
+
+            <div className="edit-buttons">
+     
+
+                {isEditing && (
+                    <div className={SavingLoader}>
+                        <CachedOutlinedIcon
+                            style={{ height: "13px", width: "13px" }}
+                        />{" "}
+                        Saving ...
+                    </div>
+                )}
+
+                 <FieldErrors fieldErrors={fieldErrors}/>
+
+                {isSaved && 
+                <ConfirmSave
+
+                theme={theme}
+                setIsSaved={setIsSaved} />}
+
             </div>
         </SettingsTitle>
     );

--- a/packages/main/views/DataSources/components/SectionHeader.tsx
+++ b/packages/main/views/DataSources/components/SectionHeader.tsx
@@ -80,9 +80,18 @@ const InputErrorWarning = ({ errorText }: { errorText: string }) => {
     );
 };
 
-export function SectionHeader(props: any) {
+export type SectionHeaderProps = {
+    isEditing?: boolean
+    isEdit: boolean 
+    isAdd:boolean 
+    title: string
+    fieldErrors: any 
+    onClickAdd?: () => void 
+}
+
+export function SectionHeader(props: SectionHeaderProps) {
     const { onClickAdd, isAdd, title, isEditing, fieldErrors } = props;
-    const dispatch: any = useDispatch();
+   const dispatch: any = useDispatch();
     const [isSaved, setIsSaved] = useState(false);
 
     useEffect(() => {

--- a/packages/main/views/DataSources/components/SectionHeader.tsx
+++ b/packages/main/views/DataSources/components/SectionHeader.tsx
@@ -2,7 +2,6 @@ import { SettingsTitle } from "../styles";
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import CachedOutlinedIcon from "@mui/icons-material/CachedOutlined";
 
-
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import setIsDatasourceSaved from "../store/setIsDataSourceSaved";
@@ -16,21 +15,14 @@ export type SectionHeaderProps = {
     isAdd?: boolean;
     title?: string;
     fieldErrors?: any;
-    onClickAdd?: (e?:any) => void;
+    onClickAdd?: (e?: any) => void;
 };
 
 export function SectionHeader(props: SectionHeaderProps) {
     const { onClickAdd, isAdd, title, isEditing, fieldErrors } = props;
-    const theme = useTheme()
+    const theme = useTheme();
     const dispatch: any = useDispatch();
     const [isSaved, setIsSaved] = useState(false);
-
-
-
-    // here should go the save settings dialog
-
-    // we should add the dialog in here or a switch to alternate autosave 
-    // with save with confirmation
 
     useEffect(() => {
         if (isEditing) {
@@ -53,21 +45,19 @@ export function SectionHeader(props: SectionHeaderProps) {
         <SettingsTitle>
             {title}
             {isAdd && (
-                    <>
-                        <AddOutlinedIcon
-                            fontSize={"small"}
-                            style={{
-                                cursor: "pointer",
-                                display: "flex",
-                            }}
-                            onClick={onClickAdd}
-                        />
-                    </>
-                )}
+                <>
+                    <AddOutlinedIcon
+                        fontSize={"small"}
+                        style={{
+                            cursor: "pointer",
+                            display: "flex",
+                        }}
+                        onClick={onClickAdd}
+                    />
+                </>
+            )}
 
             <div className="edit-buttons">
-     
-
                 {isEditing && (
                     <div className={SavingLoader}>
                         <CachedOutlinedIcon
@@ -77,14 +67,11 @@ export function SectionHeader(props: SectionHeaderProps) {
                     </div>
                 )}
 
-                 <FieldErrors fieldErrors={fieldErrors}/>
+                <FieldErrors fieldErrors={fieldErrors} />
 
-                {isSaved && 
-                <ConfirmSave
-
-                theme={theme}
-                setIsSaved={setIsSaved} />}
-
+                {isSaved && (
+                    <ConfirmSave theme={theme} setIsSaved={setIsSaved} />
+                )}
             </div>
         </SettingsTitle>
     );

--- a/packages/main/views/DataSources/components/SectionHeader.tsx
+++ b/packages/main/views/DataSources/components/SectionHeader.tsx
@@ -1,7 +1,6 @@
 import { SettingsTitle } from "../styles";
 import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
 import CachedOutlinedIcon from "@mui/icons-material/CachedOutlined";
-
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import setIsDatasourceSaved from "../store/setIsDataSourceSaved";
@@ -9,6 +8,8 @@ import useTheme from "@ui/theme/useTheme";
 import { SavingLoader } from "./header.styles";
 import { ConfirmSave } from "./ConfirmSave";
 import { FieldErrors } from "./FieldErrors";
+import { Tooltip } from "@mui/material";
+
 export type SectionHeaderProps = {
     isEditing?: boolean;
     isEdit?: boolean;
@@ -43,19 +44,23 @@ export function SectionHeader(props: SectionHeaderProps) {
 
     return (
         <SettingsTitle>
-            {title}
-            {isAdd && (
-                <>
-                    <AddOutlinedIcon
-                        fontSize={"small"}
-                        style={{
-                            cursor: "pointer",
-                            display: "flex",
-                        }}
-                        onClick={onClickAdd}
-                    />
-                </>
-            )}
+            <div style={{ display: "flex", alignItems: "center", gap: ".5em" }}>
+                {title}
+                {isAdd && (
+                    <>
+                        <Tooltip title={`Add ${title}`}>
+                            <AddOutlinedIcon
+                                fontSize={"small"}
+                                style={{
+                                    cursor: "pointer",
+                                    display: "flex",
+                                }}
+                                onClick={onClickAdd}
+                            />
+                        </Tooltip>
+                    </>
+                )}
+            </div>
 
             <div className="edit-buttons">
                 {isEditing && (

--- a/packages/main/views/DataSources/components/header.styles.ts
+++ b/packages/main/views/DataSources/components/header.styles.ts
@@ -1,0 +1,51 @@
+import { css } from '@emotion/css'
+import { QrynTheme } from '@ui/theme/types';
+
+export const confirmSaveLoaderIcon = css`
+    height: 12px !important;
+    width: 12px !important;
+    color: white;
+    margin: 0px 4px;
+`;
+
+export const confirmSaveLoaderCont = (theme: QrynTheme) => css`
+    display: flex;
+    align-items: center;
+    background: ${theme.primary};
+    color: white;
+    font-size: 11px;
+    padding: 4px;
+    border-radius: 3px;
+    margin-right: 10px;
+    cursor: pointer;
+    span {
+        margin-right: 4px;
+        font-weight: bold;
+    }
+`;
+
+export const SavingLoader = css`
+    display: flex;
+    align-items: center;
+    font-size: 12px;
+    &.loading-icon {
+        height: 14px;
+        width: 14px;
+    }
+`;
+
+export const inputErrorCont = css`
+    display: flex;
+    align-items: center;
+    background: #b62c14;
+    color: white;
+    font-size: 12px;
+    padding: 4px;
+    border-radius: 3px;
+    margin-right: 10px;
+    cursor: pointer;
+    span {
+        margin-right: 4px;
+        font-weight: bold;
+    }
+`;

--- a/packages/main/views/DataSources/hooks/useStoreSettings.ts
+++ b/packages/main/views/DataSources/hooks/useStoreSettings.ts
@@ -1,0 +1,20 @@
+import { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import setDataSources from "../store/setDataSources";
+
+export const useStoreSettings = () => {
+    const state = useSelector(({ dataSources }: any) => dataSources);
+    const dispatch: any = useDispatch();
+
+    const [settings, setSettings] = useState(state);
+    const storeDataSources = () => {
+        localStorage.setItem("dataSources", JSON.stringify(settings));
+        dispatch(setDataSources(settings));
+    }
+
+    return {
+        settings,
+        setSettings,
+        storeDataSources,
+    };
+};

--- a/packages/main/views/DataSources/hooks/useStoreSettings.ts
+++ b/packages/main/views/DataSources/hooks/useStoreSettings.ts
@@ -1,20 +1,39 @@
-import { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import setDataSources from "../store/setDataSources";
+import { create } from "zustand";
+import store from "@ui/store/store";
+
+export type SettingsStoreType = {
+    settings: any;
+    setSettings: (settings: any) => void;
+};
+const initialData = {
+    settings: store.getState().dataSources,
+};
+
+const settingsStore = create<SettingsStoreType>((set) => ({
+    ...initialData,
+    setSettings: (newSettings: any) => set(() => ({ settings: newSettings })),
+}));
 
 export const useStoreSettings = () => {
-    const state = useSelector(({ dataSources }: any) => dataSources);
     const dispatch: any = useDispatch();
 
-    const [settings, setSettings] = useState(state);
+    const { settings, setSettings } = settingsStore();
+
     const storeDataSources = () => {
         localStorage.setItem("dataSources", JSON.stringify(settings));
         dispatch(setDataSources(settings));
-    }
+    };
+
+    const storeSettings = (newSetting) => {
+        setSettings(newSetting);
+    };
 
     return {
         settings,
         setSettings,
+        storeSettings,
         storeDataSources,
     };
 };

--- a/packages/main/views/DataSources/store/setDataSources.ts
+++ b/packages/main/views/DataSources/store/setDataSources.ts
@@ -1,10 +1,8 @@
 const setDataSources = (dataSources: any) => (dispatch: any) => {
     dispatch({
-        type: 'SET_DATA_SOURCES',
-        dataSources
+        type: "SET_DATA_SOURCES",
+        dataSources,
+    });
+};
 
-    })
-} 
-
-
-export default setDataSources
+export default setDataSources;

--- a/packages/main/views/DataSources/styles.ts
+++ b/packages/main/views/DataSources/styles.ts
@@ -1,11 +1,12 @@
 import styled from "@emotion/styled";
 import { BtnSmall } from "@ui/theme/styles/Button";
+import { QrynTheme } from "@ui/theme/types";
 
-export const PageContainer: any = styled.div`
+export const PageContainer = styled.div<{ theme?: QrynTheme }>`
     overflow-x: hidden;
     border-radius: 3px;
-    background: ${({ theme }: any) => theme.background};
-    color: ${({ theme }: any) => theme.contrast};
+    background: ${({ theme }) => theme.background};
+    color: ${({ theme }) => theme.contrast};
     width: 100%;
     height: 100%;
     overflow-y: auto;
@@ -20,7 +21,7 @@ export const PageContainer: any = styled.div`
         padding: 10px;
         margin: 10px;
         width: 100%;
-        background: ${({ theme }: any) => theme.shadow};
+        background: ${({ theme }) => theme.shadow};
         display: flex;
         flex-direction: column;
         flex: 1;
@@ -42,9 +43,9 @@ export const PageContainer: any = styled.div`
     }
     .ds-cont {
         margin-bottom: 10px;
-        border: 1px solid ${({ theme }: any) => theme.accentNeutral};
+        border: 1px solid ${({ theme }) => theme.accentNeutral};
         border-radius: 3px;
-        color: ${({ theme }: any) => theme.contrast};
+        color: ${({ theme }) => theme.contrast};
     }
 
     .ds-item {
@@ -53,7 +54,7 @@ export const PageContainer: any = styled.div`
         border-radius: 3px 3px 0px 0px;
         padding-bottom: 14px;
         display: flex;
-        color: ${({ theme }: any) => theme.contrast};
+        color: ${({ theme }) => theme.contrast};
         .logo {
             padding: 10px;
             padding-right: 20px;
@@ -68,7 +69,7 @@ export const PageContainer: any = styled.div`
             font-size: 18px;
             padding: 10px;
             padding-left: 0px;
-            color: ${({ theme }: any) => theme.contrast};
+            color: ${({ theme }) => theme.contrast};
         }
         small {
             font-size: 12px;
@@ -78,7 +79,7 @@ export const PageContainer: any = styled.div`
             cursor: pointer;
         }
         .ds-settings {
-            background: ${({ theme }: any) => theme.shadow};
+            background: ${({ theme }) => theme.shadow};
         }
     }
     .plugins-cont {
@@ -87,7 +88,7 @@ export const PageContainer: any = styled.div`
         margin: 0px 10px;
         flex-direction: column;
         padding: 10px 20px;
-        border: 1px solid ${({ theme }: any) => theme.accentNeutral};
+        border: 1px solid ${({ theme }) => theme.accentNeutral};
         border-radius: 3px;
         height: fit-content;
         .title {
@@ -97,57 +98,62 @@ export const PageContainer: any = styled.div`
     }
 `;
 
-export const Label: any = styled.div`
-    color: ${({ theme }: any) => theme.contrast};
+export const Label = styled.div<{ theme?: QrynTheme; width?: number }>`
+    color: ${({ theme }) => theme.contrast};
     display: flex;
     align-items: center;
     font-size: 12px;
     padding: 0px 10px;
     //flex: 0;
     white-space: nowrap;
-    ${(props: any) => (props.width !== null ? `width:${props.width}px;` : "")}
+    ${({ width }) => (width !== null ? `width:${width}px;` : "")}
     border-radius: 3px 0px 0px 3px;
     display: flex;
     align-items: center;
     height: 26px;
 `;
 
-export const Input: any = styled.input`
+export const Input = styled.input<{
+    theme?: QrynTheme;
+    error: boolean | string;
+}>`
     display: flex;
     flex: 1;
-    background: ${({ theme }: any) => theme.deep};
-    color: ${({ theme }: any) => theme.contrast};
+    background: ${({ theme }) => theme.deep};
+    color: ${({ theme }) => theme.contrast};
     border: 1px solid
-        ${(props: any) => (props.error ? "#b62c14" : props.theme.accentNeutral)};
+        ${({ error, theme }) => (error ? "#b62c14" : theme.accentNeutral)};
     border-radius: 3px;
     justify-self: flex-end;
     height: 26px;
     padding-left: 8px;
 `;
 
-export const TextArea: any = styled.textarea`
+export const TextArea = styled.textarea<{ theme?: QrynTheme }>`
     display: flex;
     flex: 1;
-    background: ${({ theme }: any) => theme.deep};
-    color: ${({ theme }: any) => theme.contrast};
-    border: 1px solid ${({ theme }: any) => theme.accentNeutral};
+    background: ${({ theme }) => theme.deep};
+    color: ${({ theme }) => theme.contrast};
+    border: 1px solid ${({ theme }) => theme.accentNeutral};
     border-radius: 3px;
     justify-self: flex-end;
     padding-left: 8px;
 `;
 
-export const InputGroup: any = styled.div`
+export const InputGroup = styled.div<{
+    theme?: QrynTheme;
+    width?: number | string;
+}>`
     display: flex;
     flex-direction: row;
     margin-top: 5px;
     align-items: center;
-    ${(props: any) =>
-        props?.width && props?.width === "normal" ? "" : "flex:1;"}
+    ${({ width }) => (width && width === "normal" ? "" : "flex:1;")}
     //flex: 1;
     select {
-        background: ${({ theme }: any) => theme.deep};
-        color: ${({ theme }: any) => theme.contrast};
-        border: 1px solid ${({ theme }: any) => theme.accentNeutral};
+        background: ${({ theme }) => theme.deep};
+        color: ${({ theme }) => theme.contrast};
+        border: 1px solid ${({ theme }) => theme.accentNeutral};
         border-radius: 3px;
         font-size: 12px;
         height: 30px;
@@ -165,7 +171,7 @@ export const InputGroup: any = styled.div`
     }
 `;
 
-export const InputCol: any = styled.div`
+export const InputCol = styled.div`
     display: flex;
     margin: 15px 0px;
     margin-left: 14px;
@@ -177,24 +183,24 @@ export const InputCol: any = styled.div`
     }
 `;
 
-export const InputHeaderCol: any = styled.div`
+export const InputHeaderCol = styled.div`
     display: flex;
     margin: 15px 0px;
     margin-left: 14px;
     align-items: center;
 `;
-export const InputCont: any = styled.div`
+export const InputCont = styled.div`
     padding: 10px;
 `;
-export const LinkFieldsGroup: any = styled.div`
+export const LinkFieldsGroup = styled.div<{ theme?: QrynTheme }>`
     margin: 10px 0px;
     padding-bottom: 10px;
-    border-bottom: 1px solid ${({ theme }: any) => theme.background};
+    border-bottom: 1px solid ${({ theme }) => theme.background};
 `;
 
-export const SettingsTitle: any = styled.div`
+export const SettingsTitle = styled.div<{ theme?: QrynTheme }>`
     padding: 10px;
-    border-bottom: 1px solid ${({ theme }: any) => theme.shadow};
+    border-bottom: 1px solid ${({ theme }) => theme.shadow};
     border-radius: 3px;
     display: flex;
     flex: 1;
@@ -209,20 +215,23 @@ export const SettingsTitle: any = styled.div`
     }
 `;
 
-export const DataSourceSettingsCont: any = styled.div`
+export const DataSourceSettingsCont = styled.div<{ theme?: QrynTheme }>`
     padding: 10px;
     border-radius: 0px 0px 3px 3px;
-    border-top: 1px solid ${({ theme }: any) => theme.accentNeutral};
+    border-top: 1px solid ${({ theme }) => theme.accentNeutral};
 `;
 
-export const DsButtonStyled: any = styled(BtnSmall)`
-    
-    background: ${(props: any) =>
-        props.primary ? props.theme.primary : props.theme.neutral};
+export const DsButtonStyled = styled(BtnSmall)<{
+    theme?: QrynTheme;
+    primary?: boolean;
+    disabled?: boolean;
+}>`
+    background: ${({ primary, theme }) =>
+        primary ? theme.primary : theme.neutral};
 
-    border: 1px solid ${({ theme }: any) => theme.accentNeutral};
-    color: ${(props: any) =>
-        props.primary ? props.theme.maxContrast : props.theme.contrast};
+    border: 1px solid ${({ theme }) => theme.accentNeutral};
+    color: ${({ primary, theme }) =>
+        primary ? theme.maxContrast : theme.contrast};
     margin-left: 5px;
     transition: 0.25s all;
     justify-content: center;
@@ -230,15 +239,16 @@ export const DsButtonStyled: any = styled(BtnSmall)`
     height: 26px;
     display: flex;
     &:hover {
-        background: ${({ theme, disabled }: any) => disabled ? theme.neutral : theme.primaryLight};
-        color: ${(props: any) =>
-            props.primary ? props.theme.contrast : props.theme.maxContrast};
+        background: ${({ theme, disabled }) =>
+            disabled ? theme.neutral : theme.primaryLight};
+        color: ${({ primary, theme }) =>
+            primary ? theme.contrast : theme.maxContrast};
     }
     &:disabled {
-        background: ${({ theme }: any) => theme.neutral};
-        border: 1px solid ${({ theme }: any) => theme.accentNeutral};
+        background: ${({ theme }) => theme.neutral};
+        border: 1px solid ${({ theme }) => theme.accentNeutral};
         cursor: not-allowed;
-        color: ${({ theme }: any) => theme.contrast};
+        color: ${({ theme }) => theme.contrast};
     }
     @media screen and (max-width: 1070px) {
         display: flex;

--- a/packages/main/views/DataSources/ui/Field.tsx
+++ b/packages/main/views/DataSources/ui/Field.tsx
@@ -2,7 +2,10 @@ import { InputGroup, Label, Input } from "../styles";
 import DOMPurify from "isomorphic-dompurify";
 export const Field = (props: any) => {
     const { value, label, onChange, locked, type, placeholder, error, labelWidth} = props;
-    return (
+  
+  // set an initial value and a value for cancelling 
+  // that should be previous stored value
+  return (
         <InputGroup>
             <Label width={labelWidth||null}>{label}</Label>
             <Input

--- a/packages/main/views/DataSources/ui/Select.tsx
+++ b/packages/main/views/DataSources/ui/Select.tsx
@@ -1,5 +1,5 @@
 import { cx, css } from "@emotion/css";
-import DOMPurify from 'isomorphic-dompurify'
+import DOMPurify from "isomorphic-dompurify";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { InputGroup, Label } from "../styles";
 
@@ -7,7 +7,7 @@ const FlexOne = (fullWidth: any) => css`
     display: flex;
     min-width: 100px;
     flex: ${fullWidth ? 1 : 0};
-    -ms-flex:${fullWidth ? 1 : 0};
+    -ms-flex: ${fullWidth ? 1 : 0};
 `;
 
 export const Select = ({
@@ -25,13 +25,12 @@ export const Select = ({
     const selectRef: any = useRef(null);
 
     const formattedSelect = useMemo(() => {
-        if (typeof opts[0] === "string") {
-            return opts.map((k: string) => ({
+        if (opts && opts[0] && typeof opts[0] === "string") {
+            return opts?.map((k: string) => ({
                 value: k,
-                name:k,
+                name: k,
             }));
-        } else
-       return opts
+        } else return opts;
     }, [opts]);
 
     useEffect(() => {
@@ -42,12 +41,13 @@ export const Select = ({
             setInitialValue(selected);
             selectRef.current.value = selected;
         }
-          
     }, [value]);
 
     return (
         <InputGroup width={width}>
-            {label?.length > 0 && <Label width={labelWidth || null}>{label}</Label>}
+            {label?.length > 0 && (
+                <Label width={labelWidth || null}>{label}</Label>
+            )}
             <select
                 ref={selectRef}
                 className={cx(FlexOne(fullWidth))}
@@ -56,10 +56,7 @@ export const Select = ({
                 onChange={(e) => onChange(e, name)}
             >
                 {formattedSelect?.map((field: any, key: number) => (
-                    <option
-                        key={key}
-                        value={DOMPurify.sanitize(field.value)}
-                    >
+                    <option key={key} value={DOMPurify.sanitize(field.value)}>
                         {field.name}
                     </option>
                 ))}

--- a/packages/main/views/DataSources/views/Settings.tsx
+++ b/packages/main/views/DataSources/views/Settings.tsx
@@ -7,19 +7,15 @@ import {
     SectionHeader,
     AuthFields,
 } from "../components";
-//import setDataSources from "../store/setDataSources";
 
 import { DataSourceSettingsCont, InputCont, InputCol } from "../styles";
 import { Field } from "../ui";
 import { useStoreSettings } from "../hooks/useStoreSettings";
 
-
 export const Settings = (props: any) => {
- 
-    // sets the initial and editable data
-    const [settingsData, setSettingsData] = useState(props)
-    const { settings, setSettings } = useStoreSettings()
-  
+    const [settingsData, setSettingsData] = useState(props);
+    const { settings, storeSettings } = useStoreSettings();
+
     const [fieldErrors, setFieldErrors] = useState({
         url: false,
         protocol: false,
@@ -32,14 +28,12 @@ export const Settings = (props: any) => {
                 field[prop] = val;
             }
         });
-
         return arrayClone;
     };
 
     const [isEditing, setIsEditing] = useState(false);
 
     const checkURLProtocol = (value: URL | any) => {
-
         try {
             const current_protocol = window.location.protocol;
             const value_protocol = new URL(value)["protocol"];
@@ -52,8 +46,7 @@ export const Settings = (props: any) => {
     const onChange = (e: any, name: any) => {
         setIsEditing(() => true);
         const value = e.target.value;
-        console.log(value,name)
-        // check here if name === url
+
         if (name === "url") {
             const protocol_match = checkURLProtocol(value);
 
@@ -71,15 +64,10 @@ export const Settings = (props: any) => {
                     protocol: false,
                     url: false,
                 }));
+
                 const newVal = onFieldChange(name, value);
-                console.log(newVal)
-               setSettings( ()=> newVal)
 
-                //setSettingsData( (prev) => ({...prev, ...newVal}))
-
-                // localStorage.setItem("dataSources", JSON.stringify(newVal));
-                // dispatch(setDataSources(newVal));
-             //   saveSettings(newVal)
+                storeSettings(newVal);
 
                 setTimeout(() => {
                     setIsEditing(() => false);
@@ -88,25 +76,18 @@ export const Settings = (props: any) => {
         }
 
         const newVal = onFieldChange(name, value);
-        console.log(newVal)
-        setSettingsData(()=> newVal)
-       // setInitialDs(newVal)
-        //setSettingsData( () => newVal)
-       // localStorage.setItem("dataSources", JSON.stringify(newVal));
-       // dispatch(setDataSources(newVal));
-      // saveSettings(newVal)
-      setSettings(()=> newVal)
+        storeSettings(newVal);
         setTimeout(() => {
             setIsEditing(() => false);
         }, 800);
     };
 
-
-
-    useEffect(()=>{
-        setSettingsData((prev) => ({ ...prev, ...settings?.find(f => f.id === prev.id)}))
-
-    },[settings])
+    useEffect(() => {
+        setSettingsData((prev) => ({
+            ...prev,
+            ...settings?.find((f) => f.id === prev.id),
+        }));
+    }, [settings]);
 
     return (
         <DataSourceSettingsCont>
@@ -116,7 +97,6 @@ export const Settings = (props: any) => {
                 isAdd={false}
                 title={"DataSource Settings"}
                 fieldErrors={fieldErrors}
-              
             />
 
             <InputCont>
@@ -140,27 +120,24 @@ export const Settings = (props: any) => {
                 id={settingsData.id}
                 auth={settingsData.auth}
                 dataSources={settings}
-                onDsChange={setSettings}
-
-             //{...props} 
-             />
+                onDsChange={storeSettings}
+            />
 
             <DataSourceHeaders
-             id={settingsData.id}
-             cors={settingsData.cors} 
-             headers={settingsData.headers} 
-             dataSources={settings}
-             onDsChange={setSettings}
-              />
+                id={settingsData.id}
+                cors={settingsData.cors}
+                headers={settingsData.headers}
+                dataSources={settings}
+                onDsChange={storeSettings}
+            />
 
             <LinkedFields
-            // {...props} 
-            id={settingsData.id}
-            name={settingsData.name}
-            onDsChange={setSettings}
-            dataSources={settings}
-            linkedFields={settingsData.linkedFields} />
-            
+                id={settingsData.id}
+                name={settingsData.name}
+                onDsChange={storeSettings}
+                dataSources={settings}
+                linkedFields={settingsData.linkedFields}
+            />
         </DataSourceSettingsCont>
     );
 };

--- a/packages/main/views/DataSources/views/Settings.tsx
+++ b/packages/main/views/DataSources/views/Settings.tsx
@@ -153,8 +153,13 @@ export const Settings = (props: any) => {
               />
 
             <LinkedFields
-             {...props} 
-             linkedFields={settingsData.linkedFields} />
+            // {...props} 
+            id={settingsData.id}
+            name={settingsData.name}
+            onDsChange={setInitialDs}
+            dataSources={initialDs}
+            linkedFields={settingsData.linkedFields} />
+            
         </DataSourceSettingsCont>
     );
 };

--- a/packages/main/views/DataSources/views/Settings.tsx
+++ b/packages/main/views/DataSources/views/Settings.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
-import {  useSelector } from "react-redux";
+import { useEffect, useState } from "react";
+
 import DOMPurify from "isomorphic-dompurify";
 import {
     DataSourceHeaders,
@@ -11,34 +11,22 @@ import {
 
 import { DataSourceSettingsCont, InputCont, InputCol } from "../styles";
 import { Field } from "../ui";
-
+import { useStoreSettings } from "../hooks/useStoreSettings";
 
 
 export const Settings = (props: any) => {
-    const state = useSelector(({ dataSources }: any) => dataSources);
-    const { saveSettings } = props
+ 
     // sets the initial and editable data
     const [settingsData, setSettingsData] = useState(props)
-    const [initialDs, setInitialDs] = useState(state)
-    // we will pass all props into the processor and from there get the initial values 
-
-    //console.log(props) // this will be the initial fields before saving 
-    // the ones triggered on the cancel button
-    
-
-    // const { headers, id, linkedFields, name, url, cors }: any = props;
-    
-
+    const { settings, setSettings } = useStoreSettings()
   
     const [fieldErrors, setFieldErrors] = useState({
         url: false,
         protocol: false,
     });
     const onFieldChange = (prop: any, value: any) => {
-        console.log(prop, value)
         let val = value;
-        const arrayClone = JSON.parse(JSON.stringify(initialDs));
-        
+        const arrayClone = JSON.parse(JSON.stringify(settings));
         arrayClone.forEach((field: any) => {
             if (field.id === settingsData.id) {
                 field[prop] = val;
@@ -84,12 +72,15 @@ export const Settings = (props: any) => {
                     url: false,
                 }));
                 const newVal = onFieldChange(name, value);
-                setInitialDs( newVal)
+                console.log(newVal)
+               setSettings( ()=> newVal)
+
                 //setSettingsData( (prev) => ({...prev, ...newVal}))
 
                 // localStorage.setItem("dataSources", JSON.stringify(newVal));
                 // dispatch(setDataSources(newVal));
-                saveSettings(newVal)
+             //   saveSettings(newVal)
+
                 setTimeout(() => {
                     setIsEditing(() => false);
                 }, 800);
@@ -97,26 +88,25 @@ export const Settings = (props: any) => {
         }
 
         const newVal = onFieldChange(name, value);
-        setInitialDs(newVal)
+        console.log(newVal)
+        setSettingsData(()=> newVal)
+       // setInitialDs(newVal)
         //setSettingsData( () => newVal)
        // localStorage.setItem("dataSources", JSON.stringify(newVal));
        // dispatch(setDataSources(newVal));
-       saveSettings(newVal)
+      // saveSettings(newVal)
+      setSettings(()=> newVal)
         setTimeout(() => {
             setIsEditing(() => false);
         }, 800);
     };
 
-    const onSaveDsSettings = useCallback(()=>{
-        saveSettings(initialDs)
-      
 
-    },[initialDs])
 
     useEffect(()=>{
-        setSettingsData((prev) => ({ ...prev, ...initialDs?.find(f => f.id === prev.id)}))
+        setSettingsData((prev) => ({ ...prev, ...settings?.find(f => f.id === prev.id)}))
 
-    },[initialDs])
+    },[settings])
 
     return (
         <DataSourceSettingsCont>
@@ -126,7 +116,7 @@ export const Settings = (props: any) => {
                 isAdd={false}
                 title={"DataSource Settings"}
                 fieldErrors={fieldErrors}
-                saveSettings={onSaveDsSettings}
+              
             />
 
             <InputCont>
@@ -149,8 +139,8 @@ export const Settings = (props: any) => {
             <AuthFields
                 id={settingsData.id}
                 auth={settingsData.auth}
-                dataSources={initialDs}
-                onDsChange={setInitialDs}
+                dataSources={settings}
+                onDsChange={setSettings}
 
              //{...props} 
              />
@@ -159,16 +149,16 @@ export const Settings = (props: any) => {
              id={settingsData.id}
              cors={settingsData.cors} 
              headers={settingsData.headers} 
-             dataSources={initialDs}
-             onDsChange={setInitialDs}
+             dataSources={settings}
+             onDsChange={setSettings}
               />
 
             <LinkedFields
             // {...props} 
             id={settingsData.id}
             name={settingsData.name}
-            onDsChange={setInitialDs}
-            dataSources={initialDs}
+            onDsChange={setSettings}
+            dataSources={settings}
             linkedFields={settingsData.linkedFields} />
             
         </DataSourceSettingsCont>

--- a/packages/main/views/DataSources/views/Settings.tsx
+++ b/packages/main/views/DataSources/views/Settings.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useCallback, useEffect, useState } from "react";
+import {  useSelector } from "react-redux";
 import DOMPurify from "isomorphic-dompurify";
 import {
     DataSourceHeaders,
@@ -13,8 +13,10 @@ import { DataSourceSettingsCont, InputCont, InputCol } from "../styles";
 import { Field } from "../ui";
 
 
+
 export const Settings = (props: any) => {
     const state = useSelector(({ dataSources }: any) => dataSources);
+    const { saveSettings } = props
     // sets the initial and editable data
     const [settingsData, setSettingsData] = useState(props)
     const [initialDs, setInitialDs] = useState(state)
@@ -27,7 +29,7 @@ export const Settings = (props: any) => {
     // const { headers, id, linkedFields, name, url, cors }: any = props;
     
 
-   // const dispatch: any = useDispatch();
+  
     const [fieldErrors, setFieldErrors] = useState({
         url: false,
         protocol: false,
@@ -87,6 +89,7 @@ export const Settings = (props: any) => {
 
                 // localStorage.setItem("dataSources", JSON.stringify(newVal));
                 // dispatch(setDataSources(newVal));
+                saveSettings(newVal)
                 setTimeout(() => {
                     setIsEditing(() => false);
                 }, 800);
@@ -98,10 +101,17 @@ export const Settings = (props: any) => {
         //setSettingsData( () => newVal)
        // localStorage.setItem("dataSources", JSON.stringify(newVal));
        // dispatch(setDataSources(newVal));
+       saveSettings(newVal)
         setTimeout(() => {
             setIsEditing(() => false);
         }, 800);
     };
+
+    const onSaveDsSettings = useCallback(()=>{
+        saveSettings(initialDs)
+      
+
+    },[initialDs])
 
     useEffect(()=>{
         setSettingsData((prev) => ({ ...prev, ...initialDs?.find(f => f.id === prev.id)}))
@@ -116,6 +126,7 @@ export const Settings = (props: any) => {
                 isAdd={false}
                 title={"DataSource Settings"}
                 fieldErrors={fieldErrors}
+                saveSettings={onSaveDsSettings}
             />
 
             <InputCont>

--- a/packages/main/views/DataSources/views/Settings.tsx
+++ b/packages/main/views/DataSources/views/Settings.tsx
@@ -135,7 +135,14 @@ export const Settings = (props: any) => {
                 </InputCol>
             </InputCont>
 
-            <AuthFields {...props} />
+            <AuthFields
+                id={settingsData.id}
+                auth={settingsData.auth}
+                dataSources={initialDs}
+                onDsChange={setInitialDs}
+
+             //{...props} 
+             />
 
             <DataSourceHeaders
              id={settingsData.id}
@@ -145,7 +152,9 @@ export const Settings = (props: any) => {
              onDsChange={setInitialDs}
               />
 
-            <LinkedFields {...props} linkedFields={settingsData.linkedFields} />
+            <LinkedFields
+             {...props} 
+             linkedFields={settingsData.linkedFields} />
         </DataSourceSettingsCont>
     );
 };


### PR DESCRIPTION
This changes the way datasources settings are stored

- Previously the datasources fields were changed automatically without the option of a cancel button and aborting changes

For the new changes we will have a 'Cancel' button to set back all the fields to its initial values
- adittionally will have a confirm on save dialog to confirm changes made on datasources settings
- adds a cancel button to go back to previous settings
- added Import JSON functionality

Refs: #455 
Refs: #501 